### PR TITLE
feat: Add time marker to tracks on map

### DIFF
--- a/apps/vs-code/src/providers/editors/plotJsonEditor.ts
+++ b/apps/vs-code/src/providers/editors/plotJsonEditor.ts
@@ -215,6 +215,17 @@ export class PlotJsonEditorProvider implements vscode.CustomTextEditorProvider {
         });
         stateSubscriptions.push(viewportSubscription);
 
+        // Subscribe to time changes
+        const timeSubscription = globalController.on('timeChanged', (data) => {
+            if (data.editorId === editorId && webviewPanel.visible) {
+                webviewPanel.webview.postMessage({
+                    type: 'setTimeState',
+                    timeState: data.state.timeState
+                });
+            }
+        });
+        stateSubscriptions.push(timeSubscription);
+
         // Listen for when this webview panel becomes visible (tab switching)
         webviewPanel.onDidChangeViewState(() => {
             const editorId = EditorIdManager.getEditorId(document);
@@ -524,6 +535,14 @@ export class PlotJsonEditorProvider implements vscode.CustomTextEditorProvider {
 								if (mapComponentInstance) {
 									mapComponentInstance.updateProps({
 										selectedFeatureIds: message.featureIds || []
+									});
+								}
+								break;
+
+							case 'setTimeState':
+								if (mapComponentInstance) {
+									mapComponentInstance.updateProps({
+										timeState: message.timeState
 									});
 								}
 								break;

--- a/libs/web-components/eslint.config.js
+++ b/libs/web-components/eslint.config.js
@@ -50,14 +50,24 @@ export default [
   },
   {
     // Configuration for files outside the main TypeScript project (stories, tests, config files)
-    files: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.test.tsx', '**/*.test.ts', 'tests/**/*.ts', '*.js', '*.ts', '*.cjs'],
+    files: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.test.tsx', '**/*.test.ts', 'tests/**/*.ts', '*.js', '*.ts'],
     ...tseslint.configs.disableTypeChecked,
     rules: {
       // Allow any types in Storybook stories and test files for demonstration purposes
       '@typescript-eslint/no-explicit-any': 'warn', // Downgrade from error to warning
       'react/display-name': 'off', // Storybook components often don't need display names
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }], // Downgrade for test files
-      'no-undef': 'off', // Disable for config files that might use Node.js globals
+    },
+  },
+  {
+    // Special config for CJS files like jest.config.cjs
+    files: ['jest.config.cjs'],
+    languageOptions: {
+      globals: {
+        module: 'readonly',
+        require: 'readonly',
+        __dirname: 'readonly',
+      },
     },
   },
   {

--- a/libs/web-components/eslint.config.js
+++ b/libs/web-components/eslint.config.js
@@ -50,7 +50,7 @@ export default [
   },
   {
     // Configuration for files outside the main TypeScript project (stories, tests, config files)
-    files: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.test.tsx', '**/*.test.ts', 'tests/**/*.ts', '*.js', '*.ts'],
+    files: ['**/*.stories.tsx', '**/*.stories.ts', '**/*.test.tsx', '**/*.test.ts', 'tests/**/*.ts', '*.js', '*.ts', '*.cjs'],
     ...tseslint.configs.disableTypeChecked,
     rules: {
       // Allow any types in Storybook stories and test files for demonstration purposes

--- a/libs/web-components/jest.config.cjs
+++ b/libs/web-components/jest.config.cjs
@@ -1,4 +1,5 @@
 /** @type {import('jest').Config} */
+/* eslint-env node */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/libs/web-components/jest.config.cjs
+++ b/libs/web-components/jest.config.cjs
@@ -28,9 +28,7 @@ module.exports = {
       },
     }],
   },
-  transformIgnorePatterns: [
-    'node_modules/(?!(@testing-library/.*|@storybook/.*|react-leaflet))'
-  ],
+  transformIgnorePatterns: [],
   setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
   collectCoverageFrom: [

--- a/libs/web-components/jest.config.cjs
+++ b/libs/web-components/jest.config.cjs
@@ -1,5 +1,4 @@
 /** @type {import('jest').Config} */
-/* eslint-env node */
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/libs/web-components/src/MapComponent/DebriefFeatures.tsx
+++ b/libs/web-components/src/MapComponent/DebriefFeatures.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { GeoJSONFeatureCollection } from './MapComponent';
+import { TimeState } from '@debrief/shared-types/derived/typescript/timestate';
 import { Track } from './features/Track';
 import { Point } from './features/Point';
 import { Zone } from './features/Zone';
@@ -12,6 +13,8 @@ interface DebriefFeaturesProps {
   selectedFeatureIds: (string | number)[];
   /** Callback when feature is selected/deselected */
   onSelectionChange?: (selectedFeatureIds: (string | number)[]) => void;
+  /** Current time state */
+  timeState?: TimeState;
 }
 
 /**
@@ -22,7 +25,8 @@ interface DebriefFeaturesProps {
 export const DebriefFeatures: React.FC<DebriefFeaturesProps> = ({
   geoJsonData,
   selectedFeatureIds,
-  onSelectionChange
+  onSelectionChange,
+  timeState
 }) => {
   return (
     <>
@@ -31,7 +35,8 @@ export const DebriefFeatures: React.FC<DebriefFeaturesProps> = ({
         const commonProps = {
           feature,
           selectedFeatureIds,
-          onSelectionChange
+          onSelectionChange,
+          timeState
         };
         const key = feature.id || index;
 

--- a/libs/web-components/src/MapComponent/MapComponent.css
+++ b/libs/web-components/src/MapComponent/MapComponent.css
@@ -31,3 +31,12 @@
 .selected-feature.animate {
   animation: whiteGlow 2s ease-in-out infinite;
 }
+
+/* Time marker styles */
+.time-marker div {
+  background-color: rgba(255, 0, 0, 0.7);
+  border: 1px solid #ff0000;
+  border-radius: 2px;
+  width: 100%;
+  height: 100%;
+}

--- a/libs/web-components/src/MapComponent/MapComponent.test.tsx
+++ b/libs/web-components/src/MapComponent/MapComponent.test.tsx
@@ -4,33 +4,55 @@ import { MapComponent } from './MapComponent';
 import type { GeoJSONFeatureCollection } from './MapComponent';
 
 // Mock Leaflet since it requires DOM and canvas
+const mapInstance = {
+  setView: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+  remove: jest.fn(),
+  addLayer: jest.fn(),
+  removeLayer: jest.fn(),
+  fitBounds: jest.fn(),
+  panTo: jest.fn(),
+  getCenter: jest.fn(() => ({ lat: 51.505, lng: -0.09 })),
+  getZoom: jest.fn(() => 13),
+  invalidateSize: jest.fn(),
+};
+
+const tileLayerInstance = {
+  addTo: jest.fn(),
+};
+
+const geoJSONInstance = {
+  addTo: jest.fn(),
+  getBounds: jest.fn(),
+};
+
+const circleMarkerInstance = {
+  setStyle: jest.fn(),
+};
+
 jest.mock('leaflet', () => ({
-  map: jest.fn(() => ({
-    setView: jest.fn(),
-    on: jest.fn(),
-    remove: jest.fn(),
-    addLayer: jest.fn(),
-    removeLayer: jest.fn(),
-    fitBounds: jest.fn(),
-    panTo: jest.fn(),
-    getCenter: jest.fn(() => ({ lat: 51.505, lng: -0.09 })),
-    getZoom: jest.fn(() => 13),
-    invalidateSize: jest.fn(),
-  })),
-  tileLayer: jest.fn(() => ({
-    addTo: jest.fn(),
-  })),
-  geoJSON: jest.fn(() => ({
-    addTo: jest.fn(),
-    getBounds: jest.fn(),
-  })),
-  circleMarker: jest.fn(() => ({
-    setStyle: jest.fn(),
-  })),
+  Map: jest.fn(() => mapInstance),
+  map: jest.fn(() => mapInstance),
+  TileLayer: jest.fn(() => tileLayerInstance),
+  tileLayer: jest.fn(() => tileLayerInstance),
+  GeoJSON: jest.fn(() => geoJSONInstance),
+  geoJSON: jest.fn(() => geoJSONInstance),
+  CircleMarker: jest.fn(() => circleMarkerInstance),
+  circleMarker: jest.fn(() => circleMarkerInstance),
   latLngBounds: jest.fn(() => ({
     extend: jest.fn(),
     isValid: jest.fn(() => true),
   })),
+  icon: jest.fn(() => ({})),
+  divIcon: jest.fn(() => ({})),
+  Marker: {
+    prototype: {
+      options: {
+        icon: {},
+      },
+    },
+  },
 }));
 
 const sampleGeoJSON: GeoJSONFeatureCollection = {

--- a/libs/web-components/src/MapComponent/MapComponent.tsx
+++ b/libs/web-components/src/MapComponent/MapComponent.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 import { MapContainer, TileLayer, useMapEvents, useMap } from 'react-leaflet';
-import L from 'leaflet';
+import * as L from 'leaflet';
 import { DebriefFeatures } from './DebriefFeatures';
 import { isFeatureVisible } from './utils/featureUtils';
 import { calculateFeatureBounds } from './utils/boundsUtils';
+import { TimeState } from '@debrief/shared-types/derived/typescript/timestate';
 import './MapComponent.css';
 // Note: Consumer applications need to import 'leaflet/dist/leaflet.css' separately
 
@@ -58,6 +59,8 @@ export interface MapComponentProps {
   className?: string;
   /** Container ID for the map */
   mapId?: string;
+  /** Current time state */
+  timeState?: TimeState;
 }
 
 // Helper components for React Leaflet integration
@@ -118,7 +121,8 @@ export const MapComponent: React.FC<MapComponentProps> = ({
   onMapStateChange,
   initialMapState,
   className = '',
-  mapId: _mapId = 'map'
+  mapId: _mapId = 'map',
+  timeState,
 }) => {
   const [currentData, setCurrentData] = useState<GeoJSONFeatureCollection | null>(null);
   const mapRef = useRef<L.Map | null>(null);
@@ -238,6 +242,7 @@ export const MapComponent: React.FC<MapComponentProps> = ({
             geoJsonData={currentData}
             selectedFeatureIds={selectedFeatureIds}
             onSelectionChange={onSelectionChange}
+            timeState={timeState}
           />
         )}
       </MapContainer>


### PR DESCRIPTION
This change introduces a time marker on the map that shows the position of a track at a given time.

The `MapComponent` now accepts a `timeState` prop, which is passed down from the VS Code extension. The `Track` component uses this `timeState` to calculate the closest point on the track and renders a rectangular marker at that position.

This involved:
- Updating the `plotJsonEditor` to listen for `timeChanged` events and pass the `timeState` to the webview.
- Modifying the `MapComponent`, `DebriefFeatures`, and `Track` components to handle the `timeState` prop.
- Adding the logic to find the closest time and render the marker in `Track.tsx`.
- Adding CSS for the new time marker.
- Fixing the Jest test setup for the web components to handle Leaflet and react-leaflet correctly.