### PR TITLE
fix: Update PR cleanup workflow to use Fly.io instead of Heroku

### DIFF
--- a/.github/workflows/toolvault-pr-cleanup.yml
+++ b/.github/workflows/toolvault-pr-cleanup.yml
@@ -12,26 +12,30 @@ jobs:
     if: github.event.pull_request.merged == true
     
     steps:
-    - name: Install Heroku CLI
-      run: |
-        curl https://cli-assets.heroku.com/install.sh | sh
-        heroku --version
+    - name: Setup Fly CLI
+      uses: superfly/flyctl-actions/setup-flyctl@master
     
-    - name: Cleanup Heroku PR app
+    - name: Cleanup Fly.io PR app
       env:
-        HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
       run: |
-        echo "$HEROKU_API_KEY" | heroku auth:token
+        if [ -z "$FLY_API_TOKEN" ]; then
+          echo "⚠️ FLY_API_TOKEN not configured, skipping Fly.io cleanup"
+          echo "cleanup_status=skipped" >> $GITHUB_ENV
+          exit 0
+        fi
         
         APP_NAME="toolvault-pr-${{ github.event.number }}"
         
         # Check if app exists and delete it
-        if heroku apps:info $APP_NAME > /dev/null 2>&1; then
-          echo "Deleting Heroku app: $APP_NAME"
-          heroku apps:destroy $APP_NAME --confirm $APP_NAME
-          echo "✅ Heroku app deleted successfully"
+        if flyctl apps list | grep -q "^${APP_NAME}"; then
+          echo "Deleting Fly.io app: $APP_NAME"
+          flyctl apps destroy "$APP_NAME" --yes
+          echo "✅ Fly.io app deleted successfully"
+          echo "cleanup_status=success" >> $GITHUB_ENV
         else
-          echo "ℹ️ Heroku app $APP_NAME not found, nothing to cleanup"
+          echo "ℹ️ Fly.io app $APP_NAME not found, nothing to cleanup"
+          echo "cleanup_status=not_found" >> $GITHUB_ENV
         fi
     
     - name: Comment on PR
@@ -39,11 +43,23 @@ jobs:
       with:
         script: |
           const prNumber = context.payload.pull_request.number;
+          const cleanupStatus = process.env.cleanup_status;
+          
+          let statusMessage = '';
+          if (cleanupStatus === 'success') {
+            statusMessage = `The preview Fly.io app \`toolvault-pr-${prNumber}\` has been cleaned up after PR merge.`;
+          } else if (cleanupStatus === 'not_found') {
+            statusMessage = `No preview app found for \`toolvault-pr-${prNumber}\` - nothing to cleanup.`;
+          } else if (cleanupStatus === 'skipped') {
+            statusMessage = `Preview app cleanup skipped - Fly.io credentials not configured.`;
+          } else {
+            statusMessage = `Preview app cleanup completed for \`toolvault-pr-${prNumber}\`.`;
+          }
           
           const comment = `
           ## 🧹 Tool Vault Cleanup Complete
           
-          The preview Heroku app \`toolvault-pr-${prNumber}\` has been cleaned up after PR merge.
+          ${statusMessage}
           `;
           
           github.rest.issues.createComment({

--- a/libs/tool-vault-packager/package-lock.json
+++ b/libs/tool-vault-packager/package-lock.json
@@ -1,0 +1,94 @@
+{
+  "name": "tool-vault-packager",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tool-vault-packager",
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@playwright/test": "^1.55.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Replace Heroku CLI setup with Fly.io CLI setup
- Update app deletion logic to use 'flyctl apps destroy'
- Add proper error handling for missing FLY_API_TOKEN
- Improve PR comment messaging with cleanup status
- Use app name pattern 'toolvault-pr-{number}' matching deployment

This fixes the issue where PR preview machines on Fly.io weren't being cleaned up because the workflow was trying to delete non-existent Heroku apps instead.