### PR TITLE
feat: Display full source files in Code tab instead of method excerpts

### DIFF
--- a/libs/tool-vault-packager/discovery.py
+++ b/libs/tool-vault-packager/discovery.py
@@ -262,15 +262,15 @@ def load_sample_inputs(inputs_dir: Path) -> List[Dict[str, Any]]:
 
 
 def get_pretty_printed_source(func: Callable, file_path: Path) -> str:
-    """Extract and format the source code for a function."""
+    """Extract and format the complete source file."""
     try:
-        # Get the source code of the function
-        source = inspect.getsource(func)
-        return source.strip()
+        # Primary: read the entire file for complete context
+        return file_path.read_text(encoding='utf-8')
     except Exception as e:
-        # Fallback: read the entire file if we can't get function source
+        # Fallback: get just the function if file read fails
         try:
-            return file_path.read_text(encoding='utf-8')
+            source = inspect.getsource(func)
+            return f"# Note: Full file unavailable, showing function only\n\n{source.strip()}"
         except Exception:
             return f"# Error extracting source code: {e}"
 

--- a/libs/tool-vault-packager/packager.py
+++ b/libs/tool-vault-packager/packager.py
@@ -66,7 +66,7 @@ def generate_highlighted_source_html(tool_name: str, source_code: str) -> str:
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{tool_name} - Source Code</title>
+    <title>{tool_name} - Complete Source File</title>
     <style>
         body {{ 
             font-family: 'Consolas', 'Monaco', 'Courier New', monospace; 
@@ -122,7 +122,7 @@ def generate_highlighted_source_html(tool_name: str, source_code: str) -> str:
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{tool_name} - Source Code</title>
+    <title>{tool_name} - Complete Source File</title>
     <style>
         body {{ 
             font-family: 'Consolas', 'Monaco', 'Courier New', monospace; 


### PR DESCRIPTION
## Summary
- Modified Tool Vault Packager to display complete source files in the Code tab instead of just method excerpts
- Updated HTML generation to show full file context including imports and Pydantic models
- Changed HTML titles from "Source Code" to "Complete Source File" for clarity

## Changes Made
- Updated `get_pretty_printed_source()` in `discovery.py` to prioritize reading complete files over extracting method source
- Modified HTML title generation in `packager.py` to reflect the new complete file display behavior
- Improved user experience by providing full context when viewing tool source code

## Test Plan
- [ ] Verify that Code tab now displays complete source files
- [ ] Confirm HTML titles show "Complete Source File" 
- [ ] Test with tools that have Pydantic models and imports to ensure full context is visible
- [ ] Validate backward compatibility with existing tool packages

Resolves #118