### PR TITLE
feat: refactor ToolExecuteButton and OutlineViewParent to use internal toggle buttons for tool visibility and descriptions

### DIFF
--- a/libs/web-components/src/OutlineViewParent/OutlineViewParent.stories.tsx
+++ b/libs/web-components/src/OutlineViewParent/OutlineViewParent.stories.tsx
@@ -33,8 +33,6 @@ type Story = StoryObj<typeof OutlineViewParent>;
 interface OutlineViewParentDemoProps {
   initialSelection?: string[];
   initialSmartFiltering?: boolean;
-  initialShowAllTools?: boolean;
-  initialShowDescriptions?: boolean;
 }
 
 interface SampleDataState {
@@ -108,15 +106,11 @@ const useSampleData = (): SampleDataState => {
 
 const OutlineViewParentDemo: React.FC<OutlineViewParentDemoProps> = ({
   initialSelection = [],
-  initialSmartFiltering = true,
-  initialShowAllTools = false,
-  initialShowDescriptions = true
+  initialSmartFiltering = true
 }) => {
   const { featureCollection, toolList, loading, error } = useSampleData();
   const [selection, setSelection] = React.useState<string[]>(initialSelection);
   const [enableSmartFiltering, setEnableSmartFiltering] = React.useState(initialSmartFiltering);
-  const [showAllTools, setShowAllTools] = React.useState(initialShowAllTools);
-  const [showDescriptions, setShowDescriptions] = React.useState(initialShowDescriptions);
   const [lastCommandSummary, setLastCommandSummary] = React.useState<string | null>(null);
 
   const selectedFeatureDetails = React.useMemo(() => {
@@ -194,8 +188,6 @@ const OutlineViewParentDemo: React.FC<OutlineViewParentDemoProps> = ({
           onSelectionChange={setSelection}
           onCommandExecute={handleCommandExecute}
           enableSmartFiltering={enableSmartFiltering}
-          showAllTools={showAllTools}
-          showToolDescriptions={showDescriptions}
           additionalToolbarContent={
             <span style={{ fontSize: '12px', opacity: 0.9 }}>
               {selection.length} selected
@@ -261,22 +253,9 @@ const OutlineViewParentDemo: React.FC<OutlineViewParentDemoProps> = ({
               />{' '}
               Enable smart filtering
             </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={showAllTools}
-                onChange={(event) => setShowAllTools(event.target.checked)}
-              />{' '}
-              Show all tools
-            </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={showDescriptions}
-                onChange={(event) => setShowDescriptions(event.target.checked)}
-              />{' '}
-              Show tool descriptions
-            </label>
+            <p style={{ color: '#666', fontSize: '12px', margin: '8px 0' }}>
+              Show All and Show Descriptions controls are now internal toggle buttons in the dropdown (🔍 and 📝)
+            </p>
           </div>
         </section>
 
@@ -314,7 +293,6 @@ export const SingleToolScenario: Story = {
   render: () => (
     <OutlineViewParentDemo
       initialSmartFiltering={false}
-      initialShowDescriptions={false}
     />
   )
 };
@@ -323,7 +301,6 @@ export const ConditionalAvailability: Story = {
   render: () => (
     <OutlineViewParentDemo
       initialSelection={[]}
-      initialShowAllTools={false}
     />
   )
 };

--- a/libs/web-components/src/OutlineViewParent/OutlineViewParent.tsx
+++ b/libs/web-components/src/OutlineViewParent/OutlineViewParent.tsx
@@ -13,8 +13,6 @@ export interface OutlineViewParentProps
   onSelectionChange?: (ids: string[]) => void;
   onCommandExecute?: (command: SelectedCommand, selectedFeatures: DebriefFeature[]) => void;
   enableSmartFiltering?: boolean;
-  showAllTools?: boolean;
-  showToolDescriptions?: boolean;
   buttonText?: string;
   menuPosition?: 'bottom' | 'top';
   additionalToolbarContent?: React.ReactNode;
@@ -28,8 +26,6 @@ export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
   onSelectionChange,
   onCommandExecute,
   enableSmartFiltering = true,
-  showAllTools = false,
-  showToolDescriptions = true,
   buttonText = 'Execute Tools',
   menuPosition = 'bottom',
   additionalToolbarContent,
@@ -101,8 +97,6 @@ export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
         buttonText={effectiveButtonText}
         menuPosition={menuPosition}
         enableSmartFiltering={enableSmartFiltering}
-        showAll={showAllTools}
-        showDescriptions={showToolDescriptions}
       />
     ];
 
@@ -120,8 +114,6 @@ export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
     isExecuteDisabled,
     menuPosition,
     selectedFeatures,
-    showAllTools,
-    showToolDescriptions,
     toolCount,
     toolList
   ]);

--- a/libs/web-components/src/ToolExecuteButton/ToolExecuteButton.css
+++ b/libs/web-components/src/ToolExecuteButton/ToolExecuteButton.css
@@ -4,10 +4,13 @@
 .search-box {
   padding: 8px;
   border-bottom: 1px solid var(--vscode-menu-border, #454545);
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
 }
 
 .search-input {
-  width: 100%;
+  flex: 1;
   padding: 6px 8px;
   border: 1px solid var(--vscode-input-border, #3c3c3c);
   background: var(--vscode-input-background, #1e1e1e);
@@ -31,6 +34,59 @@
   opacity: 1; /* Ensure placeholder is fully visible */
 }
 
+/* Toggle buttons styling */
+.toggle-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-self: stretch;
+  justify-content: center;
+}
+
+.toggle-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 15px;
+  border: 1px solid var(--vscode-button-border, #0066cc);
+  background: var(--vscode-button-secondaryBackground, #5a5a5a);
+  color: var(--vscode-button-secondaryForeground, #ffffff);
+  border-radius: 2px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  padding: 0;
+  font-size: 9px;
+  line-height: 1;
+}
+
+.toggle-button:hover {
+  background: var(--vscode-button-hoverBackground, #005ba1);
+  border-color: var(--vscode-button-hoverBackground, #005ba1);
+}
+
+.toggle-button:focus {
+  outline: 1px solid var(--vscode-focusBorder, #007acc);
+  outline-offset: 1px;
+}
+
+.toggle-button.active {
+  background: var(--vscode-button-background, #0066cc);
+  border-color: var(--vscode-button-background, #0066cc);
+  color: var(--vscode-button-foreground, #ffffff);
+}
+
+.toggle-button.active:hover {
+  background: var(--vscode-button-hoverBackground, #005ba1);
+  border-color: var(--vscode-button-hoverBackground, #005ba1);
+}
+
+.toggle-icon {
+  display: block;
+  font-size: 8px;
+  line-height: 1;
+}
+
 /* Ensure good visibility in light themes */
 @media (prefers-color-scheme: light) {
   .search-input {
@@ -41,6 +97,21 @@
 
   .search-input::placeholder {
     color: var(--vscode-input-placeholderForeground, #666666);
+  }
+
+  .toggle-button {
+    background: var(--vscode-button-secondaryBackground, #e0e0e0);
+    color: var(--vscode-button-secondaryForeground, #333333);
+    border-color: var(--vscode-button-border, #cccccc);
+  }
+
+  .toggle-button:hover {
+    background: var(--vscode-button-hoverBackground, #d0d0d0);
+  }
+
+  .toggle-button.active {
+    background: var(--vscode-button-background, #0066cc);
+    color: var(--vscode-button-foreground, #ffffff);
   }
 }
 .tool-execute-button-container {
@@ -220,7 +291,8 @@
 @media (prefers-reduced-motion: reduce) {
   .dropdown-arrow,
   .tool-execute-button,
-  .tool-menu-item {
+  .tool-menu-item,
+  .toggle-button {
     transition: none;
   }
 }
@@ -239,5 +311,14 @@
   .tool-menu-item:focus {
     border: 1px solid var(--vscode-focusBorder, #0066cc);
     margin: 1px;
+  }
+
+  .toggle-button {
+    border: 2px solid;
+  }
+
+  .toggle-button:focus {
+    outline: 2px solid var(--vscode-focusBorder, #0066cc);
+    outline-offset: 2px;
   }
 }

--- a/libs/web-components/src/ToolExecuteButton/ToolExecuteButton.tsx
+++ b/libs/web-components/src/ToolExecuteButton/ToolExecuteButton.tsx
@@ -17,8 +17,6 @@ export interface ToolExecuteButtonProps {
   buttonText?: string;
   menuPosition?: 'bottom' | 'top';
   enableSmartFiltering?: boolean;
-  showAll?: boolean; // When true, shows all tools regardless of filtering. When false, shows only applicable tools
-  showDescriptions?: boolean; // When true, shows tool descriptions in dropdown. When false, shows only names
 }
 
 export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
@@ -29,12 +27,12 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
   buttonText = 'Execute Tools',
   menuPosition = 'bottom',
   enableSmartFiltering = false,
-  showAll = true, // Default to showing all tools for backward compatibility
-  showDescriptions = true, // Default to showing descriptions for backward compatibility
 }) => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [filterWarnings, setFilterWarnings] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
+  const [showAllState, setShowAllState] = useState(true); // Default to showing all tools
+  const [showDescriptionsState, setShowDescriptionsState] = useState(true); // Default to showing descriptions
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -56,11 +54,11 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
       const result = toolFilterService.getApplicableTools(selectedFeatures, toolsData);
       const applicableNames = new Set(result.tools.map(tool => tool.name));
 
-      // Return filtered tools or all tools based on showAll prop
-      const tools = showAll ? toolList.tools || [] : result.tools;
+      // Return filtered tools or all tools based on showAllState
+      const tools = showAllState ? toolList.tools || [] : result.tools;
 
       // Determine warnings based on filtering state
-      const warnings = !showAll ? result.warnings : [];
+      const warnings = !showAllState ? result.warnings : [];
 
       return { availableTools: tools, applicableToolNames: applicableNames, warnings };
     } catch (error) {
@@ -73,7 +71,7 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
         warnings: ['Error filtering tools - showing all available tools']
       };
     }
-  }, [toolList.tools, selectedFeatures, enableSmartFiltering, showAll, toolFilterService]);
+  }, [toolList.tools, selectedFeatures, enableSmartFiltering, showAllState, toolFilterService]);
 
   // Update filter warnings based on computed results
   React.useEffect(() => {
@@ -163,10 +161,30 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
               placeholder="Search tools..."
               className="search-input"
             />
+            <div className="toggle-buttons">
+              <button
+                className={`toggle-button ${showAllState ? 'active' : ''}`}
+                onClick={() => setShowAllState(!showAllState)}
+                title="Show all tools"
+                aria-label="Toggle show all tools"
+                type="button"
+              >
+                <span className="toggle-icon">🔍</span>
+              </button>
+              <button
+                className={`toggle-button ${showDescriptionsState ? 'active' : ''}`}
+                onClick={() => setShowDescriptionsState(!showDescriptionsState)}
+                title="Show descriptions"
+                aria-label="Toggle show descriptions"
+                type="button"
+              >
+                <span className="toggle-icon">📝</span>
+              </button>
+            </div>
           </div>
 
-          {/* Only show warnings when showAll is true - when filtering is disabled, warnings about filtered tools are not relevant */}
-          {filterWarnings.length > 0 && showAll && (
+          {/* Only show warnings when showAllState is true - when filtering is disabled, warnings about filtered tools are not relevant */}
+          {filterWarnings.length > 0 && showAllState && (
             <div className="filter-warnings">
               {filterWarnings.map((warning, index) => (
                 <div key={index} className="filter-warning">
@@ -193,7 +211,7 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
             <div className="tools-list">
               {searchFilteredTools.map((tool) => {
                 const isApplicable = applicableToolNames.has(tool.name);
-                const isDisabled = enableSmartFiltering && showAll && !isApplicable;
+                const isDisabled = enableSmartFiltering && showAllState && !isApplicable;
 
                 return (
                   <button
@@ -205,7 +223,7 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
                     aria-disabled={isDisabled}
                   >
                     <div className="tool-name">{tool.name}</div>
-                    {showDescriptions && (
+                    {showDescriptionsState && (
                       <div className="tool-description">{tool.description}</div>
                     )}
                   </button>
@@ -214,8 +232,8 @@ export const ToolExecuteButton: React.FC<ToolExecuteButtonProps> = ({
             </div>
           )}
 
-          {/* Only show the smart filtering note when showAll is true */}
-          {enableSmartFiltering && selectedFeatures.length === 0 && showAll && (
+          {/* Only show the smart filtering note when showAllState is true */}
+          {enableSmartFiltering && selectedFeatures.length === 0 && showAllState && (
             <div className="smart-filtering-note">
               Select features to see filtered tools
             </div>


### PR DESCRIPTION
## Summary

- Refactored ToolExecuteButton to use internal toggle buttons (🔍 and 📝) instead of external props for controlling tool visibility and descriptions
- Removed `showAllTools` and `showToolDescriptions` props from OutlineViewParent component
- Updated component stories and demos to reflect the new internal toggle approach
- Enhanced user experience by making controls directly accessible within the tool dropdown

## Changes

### ToolExecuteButton Component
- Added internal state management for `showAllState` and `showDescriptionsState` 
- Implemented toggle buttons in search box area with search icon (🔍) for tool filtering and document icon (📝) for descriptions
- Updated CSS styling for new toggle button layout and VS Code theme compatibility
- Removed external `showAll` and `showDescriptions` props

### OutlineViewParent Component  
- Removed `showAllTools` and `showToolDescriptions` props from component interface
- Updated stories to remove external control checkboxes and added explanatory text about internal controls

### Styling Updates
- Added responsive toggle button styling with proper VS Code theme integration
- Implemented hover states, focus indicators, and accessibility features
- Enhanced layout with flexbox for search input and toggle buttons

## Test Plan

- [ ] Verify toggle buttons appear and function correctly in tool dropdown
- [ ] Test that 🔍 button properly toggles between all tools and filtered tools  
- [ ] Test that 📝 button properly toggles tool descriptions on/off
- [ ] Confirm accessibility with keyboard navigation and screen readers
- [ ] Validate styling in both light and dark VS Code themes
- [ ] Run Storybook to verify component demos work correctly

Fixes #159