### PR TITLE
fix: remove path filters from PR cleanup workflows to prevent orphaned fly.io apps

### DIFF
--- a/.github/workflows/toolvault-pr-cleanup.yml
+++ b/.github/workflows/toolvault-pr-cleanup.yml
@@ -3,8 +3,9 @@ name: Tool Vault PR Cleanup
 on:
   pull_request:
     types: [closed]
-    paths:
-      - 'libs/tool-vault-packager/**'
+    # No path filter - cleanup should run for ALL PR closures to prevent orphaned apps
+    # Preview deployments may be triggered by various path changes, so we need to
+    # attempt cleanup regardless of which files were modified
 
 jobs:
   pr-cleanup:

--- a/.github/workflows/vs-pr-cleanup.yml
+++ b/.github/workflows/vs-pr-cleanup.yml
@@ -3,8 +3,9 @@ name: VS Code Extension PR Cleanup
 on:
   pull_request:
     types: [closed]
-    paths:
-      - 'apps/vs-code/**'
+    # No path filter - cleanup should run for ALL PR closures to prevent orphaned apps
+    # Preview deployments may be triggered by various path changes, so we need to
+    # attempt cleanup regardless of which files were modified
 
 jobs:
   pr-cleanup:


### PR DESCRIPTION
## Summary
Fixes the issue where Tool Vault preview deployments were not being cleaned up when PRs closed, resulting in orphaned fly.io apps that accumulated costs.

## Problem
The Tool Vault cleanup workflow had a path filter that only triggered on changes to `libs/tool-vault-packager/**`, but the preview workflow also triggers on `libs/shared-types/**` changes. This mismatch caused orphaned fly.io apps when PRs modifying non-matching paths closed without cleanup.

**Example**: PR #174 modified only documentation files (`apps/vs-code/docs/**`), but a Tool Vault preview app was deployed. When the PR closed, the cleanup workflow didn't trigger because the path filter didn't match, leaving `toolvault-pr-174` running.

## Solution
- Remove path filters from both `toolvault-pr-cleanup.yml` and `vs-pr-cleanup.yml`
- Add explanatory comments about why cleanup should run unconditionally
- Cleanup workflows now run for all PR closures to prevent orphaned apps

## Why This is Safe
The cleanup scripts already handle the "app doesn't exist" case gracefully, so running unconditionally:
- ✅ Prevents cost accumulation from orphaned preview deployments
- ✅ Minimal overhead (cleanup workflows are quick and only run on PR close)
- ✅ No false positives (script checks if app exists before attempting deletion)

## Test Plan
- [x] Manually deleted orphaned `toolvault-pr-174` app
- [x] Verified no other orphaned PR apps exist
- [x] Confirmed the test failure in shared-types is pre-existing on main branch