### PR TITLE
fix: make Track geometry required (non-nullable)

### DIFF
--- a/libs/shared-types/python-src/debrief/types/features/track.py
+++ b/libs/shared-types/python-src/debrief/types/features/track.py
@@ -57,13 +57,21 @@ class TrackProperties(BaseModel):
 class DebriefTrackFeature(Feature[Union[LineString, MultiLineString], TrackProperties]):
     """A GeoJSON Feature representing a track with LineString or MultiLineString geometry."""
 
+    # Explicitly override geometry to make it required (not nullable)
+    geometry: Union[LineString, MultiLineString] = Field(
+        ...,
+        description="Track geometry must be LineString or MultiLineString"
+    )
+
     class Config:
         extra = "forbid"  # Strict validation - no additional properties
 
     @field_validator('geometry')
     @classmethod
     def validate_track_geometry(cls, v):
-        """Ensure geometry is LineString or MultiLineString."""
+        """Ensure geometry is required and is LineString or MultiLineString."""
+        if v is None:
+            raise ValueError('Track features must have a geometry')
         if not isinstance(v, (LineString, MultiLineString)):
             raise ValueError('Track features must have LineString or MultiLineString geometry')
         return v


### PR DESCRIPTION
## Summary
Modified `DebriefTrackFeature` Pydantic model to enforce required, non-nullable geometry field. Track features must now have either LineString or MultiLineString geometry - null values are rejected.

## Changes
- Explicitly override `geometry` field with `Field(...)` to make it required in `libs/shared-types/python-src/debrief/types/features/track.py:61-64`
- Updated `field_validator` to check for None before type validation in `libs/shared-types/python-src/debrief/types/features/track.py:73-74`
- Regenerated JSON schemas (no more `{"type": "null"}` in geometry anyOf)
- Regenerated TypeScript types (`Geometry = LineString | MultiLineString`, no null)

## Verification
- ✅ JSON schema `libs/shared-types/derived/json-schema/features/track.schema.json:400-409` no longer includes `{"type": "null"}`
- ✅ TypeScript type `libs/shared-types/src/types/features/track.ts:13` shows `Geometry = LineString | MultiLineString` (no null)
- ✅ Pydantic validation rejects tracks with None geometry
- ✅ Pydantic validation rejects tracks missing geometry field
- ✅ All existing tests pass
- ✅ Full monorepo build and typecheck succeed

## Test Plan
- [x] Valid track with LineString geometry accepted
- [x] Track with null geometry rejected
- [x] Track missing geometry field rejected
- [x] All package tests passing
- [x] Monorepo typecheck passing

Fixes #182