### PR TITLE
fix: update annotation schema dataType from 'zone' to 'annotation'

### DIFF
--- a/libs/shared-types/python-src/debrief/types/features/track.py
+++ b/libs/shared-types/python-src/debrief/types/features/track.py
@@ -57,13 +57,21 @@ class TrackProperties(BaseModel):
 class DebriefTrackFeature(Feature[Union[LineString, MultiLineString], TrackProperties]):
     """A GeoJSON Feature representing a track with LineString or MultiLineString geometry."""
 
+    # Explicitly override geometry to make it required (not nullable)
+    geometry: Union[LineString, MultiLineString] = Field(
+        ...,
+        description="Track geometry must be LineString or MultiLineString"
+    )
+
     class Config:
         extra = "forbid"  # Strict validation - no additional properties
 
     @field_validator('geometry')
     @classmethod
     def validate_track_geometry(cls, v):
-        """Ensure geometry is LineString or MultiLineString."""
+        """Ensure geometry is required and is LineString or MultiLineString."""
+        if v is None:
+            raise ValueError('Track features must have a geometry')
         if not isinstance(v, (LineString, MultiLineString)):
             raise ValueError('Track features must have LineString or MultiLineString geometry')
         return v

--- a/turbo.json
+++ b/turbo.json
@@ -23,7 +23,7 @@
       "outputs": []
     },
     "test": {
-      "outputs": ["coverage/**"]
+      "outputs": []
     },
     "storybook": {
       "cache": false,


### PR DESCRIPTION
## Summary

Completes the migration from `dataType: 'zone'` to `dataType: 'annotation'` across validators and test data.

## Changes

### Validator Updates
- **annotation-validator.ts**: Updated discriminator check from `'zone'` to `'annotation'`
- **featurecollection-validator.ts**: Updated classification mapping and error messages

### Test Data Fixes
- **tool-vault test samples**: Updated JSON files to use `dataType: 'annotation'`
  - `fit_to_selection/samples/mixed_features.json`
  - `select_all_visible/samples/polygon_zone_with_point.json`

### Build Configuration
- **turbo.json**: Removed `outputs: ["coverage/**"]` from test task to eliminate warnings since tests don't produce cacheable artifacts

## Fixes

Resolves #186

## Test Plan

- [x] All shared-types tests pass
- [x] All web-components tests pass  
- [x] All vs-code tests pass
- [x] No Turborepo warnings during test execution
- [x] Tool-vault Pydantic validation accepts annotation dataType