### PR TITLE
fix: remove selection requirement for ToolExecuteButton (#190)

### DIFF
--- a/libs/web-components/src/OutlineViewParent/OutlineViewParent.test.tsx
+++ b/libs/web-components/src/OutlineViewParent/OutlineViewParent.test.tsx
@@ -74,7 +74,8 @@ describe('OutlineViewParent', () => {
     );
 
     const executeButton = screen.getByRole('button', { name: /Run Tools/i });
-    expect(executeButton).toBeDisabled();
+    // Button should be enabled even with no selection (as long as tools are present)
+    expect(executeButton).not.toBeDisabled();
 
   const tree = screen.getByTestId('outline-view-tree');
   fireEvent(
@@ -85,6 +86,7 @@ describe('OutlineViewParent', () => {
   );
 
     await waitFor(() => expect(handleSelectionChange).toHaveBeenCalledWith(['feature-1']));
+    // Button should still be enabled after selection
     await waitFor(() => expect(executeButton).not.toBeDisabled());
   });
 

--- a/libs/web-components/src/OutlineViewParent/OutlineViewParent.tsx
+++ b/libs/web-components/src/OutlineViewParent/OutlineViewParent.tsx
@@ -64,7 +64,7 @@ export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
 
   const hasTools = Boolean(toolList.root?.length);
   const toolCount = toolList.root?.length || 0;
-  const isExecuteDisabled = !hasTools || selectedFeatures.length === 0;
+  const isExecuteDisabled = !hasTools;
 
   const handleSelectionChange = React.useCallback(
     (ids: string[]) => {


### PR DESCRIPTION
## Summary

Removes the feature selection requirement from the ToolExecuteButton in OutlineViewParent. The button is now enabled whenever tools exist in the vault, regardless of whether features are selected.

## Changes

- Modified `OutlineViewParent.tsx:67` to only check `!hasTools` instead of `!hasTools || selectedFeatures.length === 0`
- Updated test expectations in `OutlineViewParent.test.tsx` to reflect new behavior
- Button now allows users to browse all available tools even with no selection

## Behavior

**Before**: Button disabled when no features selected  
**After**: Button enabled when tools exist, regardless of selection state

The ToolExecuteButton's internal filtering logic handles tool applicability:
- When smart filtering is enabled and no features are selected, users see "Select features to see filtered tools"
- Tools requiring selection are appropriately disabled/filtered based on context
- Empty tool list displays helpful messaging

## Test Plan

- [x] All existing tests pass
- [x] TypeScript compilation succeeds
- [x] Linting passes
- [x] Button enabled with no selection
- [x] Button enabled with feature selection
- [x] Button disabled when no tools in vault
- [x] Smart filtering works correctly with/without selection

Fixes #190