### PR TITLE
Fix misleading ToolVaultCommand naming - rename to DebriefCommand

### DIFF
--- a/apps/vs-code/src/providers/panels/debriefActivityProvider.ts
+++ b/apps/vs-code/src/providers/panels/debriefActivityProvider.ts
@@ -535,9 +535,9 @@ export class DebriefActivityProvider implements vscode.WebviewViewProvider {
     private _handleToolExecutionSuccess(commandName: string, result: unknown): void {
         console.warn('[DebriefActivityProvider] Tool execution success:', result);
 
-        const hasToolVaultCommands = this._containsToolVaultCommands(result);
+        const hasDebriefCommands = this._containsDebriefCommands(result);
 
-        if (hasToolVaultCommands) {
+        if (hasDebriefCommands) {
             const successMessage = `Tool "${commandName}" executed successfully and plot updated`;
             vscode.window.showInformationMessage(successMessage);
         } else {
@@ -593,32 +593,32 @@ export class DebriefActivityProvider implements vscode.WebviewViewProvider {
     }
 
     /**
-     * Check if result contains ToolVaultCommands
+     * Check if result contains DebriefCommands
      */
-    private _containsToolVaultCommands(result: unknown): boolean {
+    private _containsDebriefCommands(result: unknown): boolean {
         if (!result || typeof result !== 'object') {
             return false;
         }
 
-        if (this._isToolVaultCommand(result)) {
+        if (this._isDebriefCommand(result)) {
             return true;
         }
 
         if (Array.isArray(result)) {
-            return result.some(item => this._isToolVaultCommand(item));
+            return result.some(item => this._isDebriefCommand(item));
         }
 
         if ('commands' in result && Array.isArray((result as Record<string, unknown>).commands)) {
-            return ((result as Record<string, unknown>).commands as unknown[]).some(item => this._isToolVaultCommand(item));
+            return ((result as Record<string, unknown>).commands as unknown[]).some(item => this._isDebriefCommand(item));
         }
 
         return false;
     }
 
     /**
-     * Type guard to check if an object is a ToolVaultCommand
+     * Type guard to check if an object is a DebriefCommand
      */
-    private _isToolVaultCommand(obj: unknown): boolean {
+    private _isDebriefCommand(obj: unknown): boolean {
         return (
             typeof obj === 'object' &&
             obj !== null &&

--- a/apps/vs-code/src/providers/panels/debriefOutlineProvider.ts
+++ b/apps/vs-code/src/providers/panels/debriefOutlineProvider.ts
@@ -507,10 +507,10 @@ export class DebriefOutlineProvider implements vscode.WebviewViewProvider {
   private _handleToolExecutionSuccess(commandName: string, result: unknown): void {
     console.warn('[DebriefOutlineProvider] Tool execution success:', result);
 
-    // Check if the result contains ToolVaultCommands
-    const hasToolVaultCommands = this._containsToolVaultCommands(result);
+    // Check if the result contains DebriefCommands
+    const hasDebriefCommands = this._containsDebriefCommands(result);
 
-    if (hasToolVaultCommands) {
+    if (hasDebriefCommands) {
       // If tool returned commands, those were processed by GlobalController
       const successMessage = `Tool "${commandName}" executed successfully and plot updated`;
       vscode.window.showInformationMessage(successMessage);
@@ -574,35 +574,35 @@ export class DebriefOutlineProvider implements vscode.WebviewViewProvider {
   }
 
   /**
-   * Check if result contains ToolVaultCommands
+   * Check if result contains DebriefCommands
    */
-  private _containsToolVaultCommands(result: unknown): boolean {
+  private _containsDebriefCommands(result: unknown): boolean {
     if (!result || typeof result !== 'object') {
       return false;
     }
 
-    // Check if it's a single ToolVaultCommand
-    if (this._isToolVaultCommand(result)) {
+    // Check if it's a single DebriefCommand
+    if (this._isDebriefCommand(result)) {
       return true;
     }
 
-    // Check if it's an array of ToolVaultCommands
+    // Check if it's an array of DebriefCommands
     if (Array.isArray(result)) {
-      return result.some(item => this._isToolVaultCommand(item));
+      return result.some(item => this._isDebriefCommand(item));
     }
 
     // Check if it's an object containing a commands array
     if ('commands' in result && Array.isArray((result as Record<string, unknown>).commands)) {
-      return ((result as Record<string, unknown>).commands as unknown[]).some(item => this._isToolVaultCommand(item));
+      return ((result as Record<string, unknown>).commands as unknown[]).some(item => this._isDebriefCommand(item));
     }
 
     return false;
   }
 
   /**
-   * Type guard to check if an object is a ToolVaultCommand
+   * Type guard to check if an object is a DebriefCommand
    */
-  private _isToolVaultCommand(obj: unknown): boolean {
+  private _isDebriefCommand(obj: unknown): boolean {
     return (
       typeof obj === 'object' &&
       obj !== null &&

--- a/libs/shared-types/python-src/debrief/types/tools/__init__.py
+++ b/libs/shared-types/python-src/debrief/types/tools/__init__.py
@@ -7,7 +7,7 @@ from .tool_index_node import ToolIndexNode
 from .tool_call_request import ToolCallRequest, ToolArgument
 from .tool_call_response import (
     ToolCallResponse,
-    ToolVaultCommand,
+    DebriefCommand,
     CommandType,
     MediaType,
     DataAxis,
@@ -52,7 +52,7 @@ __all__ = [
     "ToolCallRequest",
     "ToolArgument",
     "ToolCallResponse",
-    "ToolVaultCommand",
+    "DebriefCommand",
     "CommandType",
     "ToolListResponse",
 

--- a/libs/shared-types/python-src/debrief/types/tools/commands.py
+++ b/libs/shared-types/python-src/debrief/types/tools/commands.py
@@ -1,9 +1,9 @@
 """
-ToolVault command data models with typed payloads.
+Debrief command data models with typed payloads.
 
-This module provides strongly-typed command classes that extend the base ToolVaultCommand
-with specific payload types for each command. This ensures type safety when creating
-command responses from tools.
+This module provides strongly-typed command classes that extend the base DebriefCommand
+with specific payload types for each command. These commands trigger state changes in Debrief
+and ensure type safety when creating command responses from Tool Vault tools.
 """
 
 from enum import Enum
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Literal, Optional, Union
 from pydantic import BaseModel, Field
 
 # Import base models and existing payload classes from tool_call_response
-from .tool_call_response import ToolVaultCommand, ShowDataPayload, ShowImagePayload
+from .tool_call_response import DebriefCommand, ShowDataPayload, ShowImagePayload
 
 # Import Debrief feature types
 from ..features.debrief_feature_collection import DebriefFeature, DebriefFeatureCollection
@@ -24,7 +24,7 @@ from ..states.viewport_state import ViewportState
 
 
 # Feature manipulation commands
-class AddFeaturesCommand(ToolVaultCommand):
+class AddFeaturesCommand(DebriefCommand):
     """Command to add Debrief features to the map."""
     command: Literal["addFeatures"] = "addFeatures"
     payload: List[DebriefFeature] = Field(
@@ -33,7 +33,7 @@ class AddFeaturesCommand(ToolVaultCommand):
     )
 
 
-class UpdateFeaturesCommand(ToolVaultCommand):
+class UpdateFeaturesCommand(DebriefCommand):
     """Command to update existing Debrief features on the map."""
     command: Literal["updateFeatures"] = "updateFeatures"
     payload: List[DebriefFeature] = Field(
@@ -42,7 +42,7 @@ class UpdateFeaturesCommand(ToolVaultCommand):
     )
 
 
-class DeleteFeaturesCommand(ToolVaultCommand):
+class DeleteFeaturesCommand(DebriefCommand):
     """Command to delete features from the map."""
     command: Literal["deleteFeatures"] = "deleteFeatures"
     payload: List[str] = Field(
@@ -51,7 +51,7 @@ class DeleteFeaturesCommand(ToolVaultCommand):
     )
 
 
-class SetFeatureCollectionCommand(ToolVaultCommand):
+class SetFeatureCollectionCommand(DebriefCommand):
     """Command to replace the entire feature collection."""
     command: Literal["setFeatureCollection"] = "setFeatureCollection"
     payload: DebriefFeatureCollection = Field(
@@ -61,7 +61,7 @@ class SetFeatureCollectionCommand(ToolVaultCommand):
 
 
 # State management commands
-class SetViewportCommand(ToolVaultCommand):
+class SetViewportCommand(DebriefCommand):
     """Command to update the map viewport."""
     command: Literal["setViewport"] = "setViewport"
     payload: ViewportState = Field(
@@ -70,7 +70,7 @@ class SetViewportCommand(ToolVaultCommand):
     )
 
 
-class SetSelectionCommand(ToolVaultCommand):
+class SetSelectionCommand(DebriefCommand):
     """Command to update feature selection."""
     command: Literal["setSelection"] = "setSelection"
     payload: SelectionState = Field(
@@ -79,7 +79,7 @@ class SetSelectionCommand(ToolVaultCommand):
     )
 
 
-class SetTimeStateCommand(ToolVaultCommand):
+class SetTimeStateCommand(DebriefCommand):
     """Command to update the editor time state."""
     command: Literal["setTimeState"] = "setTimeState"
     payload: TimeState = Field(
@@ -88,7 +88,7 @@ class SetTimeStateCommand(ToolVaultCommand):
     )
 
 # Display commands
-class ShowTextCommand(ToolVaultCommand):
+class ShowTextCommand(DebriefCommand):
     """Command to display text to the user."""
     command: Literal["showText"] = "showText"
     payload: str = Field(
@@ -97,7 +97,7 @@ class ShowTextCommand(ToolVaultCommand):
     )
 
 
-class ShowDataCommand(ToolVaultCommand):
+class ShowDataCommand(DebriefCommand):
     """Command to display structured data to the user."""
     command: Literal["showData"] = "showData"
     payload: Union[ShowDataPayload, Dict[str, Any]] = Field(
@@ -106,7 +106,7 @@ class ShowDataCommand(ToolVaultCommand):
     )
 
 
-class ShowImageCommand(ToolVaultCommand):
+class ShowImageCommand(DebriefCommand):
     """Command to display an image to the user."""
     command: Literal["showImage"] = "showImage"
     payload: ShowImagePayload = Field(
@@ -134,7 +134,7 @@ class LogMessagePayload(BaseModel):
         extra = "forbid"
 
 
-class LogMessageCommand(ToolVaultCommand):
+class LogMessageCommand(DebriefCommand):
     """Command to log a message."""
     command: Literal["logMessage"] = "logMessage"
     payload: Union[str, LogMessagePayload] = Field(
@@ -143,12 +143,12 @@ class LogMessageCommand(ToolVaultCommand):
     )
 
 
-class CompositeCommand(ToolVaultCommand):
+class CompositeCommand(DebriefCommand):
     """Command to execute multiple commands in sequence."""
     command: Literal["composite"] = "composite"
-    payload: List[ToolVaultCommand] = Field(
+    payload: List[DebriefCommand] = Field(
         ...,
-        description="Array of commands to execute in sequence"
+        description="Array of Debrief commands to execute in sequence"
     )
 
 

--- a/libs/shared-types/python-src/debrief/types/tools/tool_call_response.py
+++ b/libs/shared-types/python-src/debrief/types/tools/tool_call_response.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, model_serializer
 
 
 class CommandType(str, Enum):
-    """Valid ToolVault command types."""
+    """Valid Debrief command types."""
     ADD_FEATURES = "addFeatures"
     UPDATE_FEATURES = "updateFeatures"
     DELETE_FEATURES = "deleteFeatures"
@@ -97,8 +97,8 @@ def _normalise_output(value: Any) -> Any:
     return value
 
 
-class ToolVaultCommand(BaseModel, ABC):
-    """A command returned by a ToolVault tool."""
+class DebriefCommand(BaseModel, ABC):
+    """A command that triggers state changes in Debrief (returned by Tool Vault tools)."""
 
     command: CommandType = Field(
         ...,
@@ -114,8 +114,8 @@ class ToolVaultCommand(BaseModel, ABC):
 
     def __init__(self, **data: Any) -> None:
         """Prevent direct instantiation of the abstract base command."""
-        if self.__class__ is ToolVaultCommand:
-            raise TypeError("ToolVaultCommand is abstract and cannot be instantiated directly")
+        if self.__class__ is DebriefCommand:
+            raise TypeError("DebriefCommand is abstract and cannot be instantiated directly")
         super().__init__(**data)
 
     @model_serializer(mode="plain")
@@ -128,7 +128,7 @@ class ToolVaultCommand(BaseModel, ABC):
         return _normalise_output(data)
 
 
-def _tool_vault_command_model_dump(self: ToolVaultCommand, *args: Any, **kwargs: Any) -> Any:
+def _debrief_command_model_dump(self: DebriefCommand, *args: Any, **kwargs: Any) -> Any:
     """Monkey-patched serializer to match legacy expectations by default."""
     if "mode" not in kwargs:
         kwargs["mode"] = "json"
@@ -138,15 +138,15 @@ def _tool_vault_command_model_dump(self: ToolVaultCommand, *args: Any, **kwargs:
     return _normalise_output(data)
 
 
-ToolVaultCommand.model_dump = _tool_vault_command_model_dump  # type: ignore[attr-defined]
+DebriefCommand.model_dump = _debrief_command_model_dump  # type: ignore[attr-defined]
 
 
 class ToolCallResponse(BaseModel):
-    """Response format for tool execution results containing ToolVault commands."""
+    """Response format for tool execution results containing Debrief commands."""
 
-    result: ToolVaultCommand = Field(
+    result: DebriefCommand = Field(
         ...,
-        description="A command returned by a ToolVault tool"
+        description="A command that triggers state changes in Debrief"
     )
     isError: bool = Field(
         False,

--- a/libs/shared-types/scripts/validate.js
+++ b/libs/shared-types/scripts/validate.js
@@ -19,7 +19,6 @@ const colors = {
 };
 
 function log(level, message) {
-  const timestamp = new Date().toISOString();
   const color = colors[level] || colors.reset;
   console.log(`${color}[${level.toUpperCase()}]${colors.reset} ${message}`);
 }
@@ -27,7 +26,7 @@ function log(level, message) {
 function getFileModTime(filePath) {
   try {
     return fs.statSync(filePath).mtime;
-  } catch (error) {
+  } catch {
     return null;
   }
 }
@@ -47,7 +46,7 @@ function getNewestFileInDir(dir, pattern = '**/*.py') {
       }
     }
     return { file: newest, mtime: newestTime ? new Date(newestTime) : null };
-  } catch (error) {
+  } catch {
     return { file: null, mtime: null };
   }
 }

--- a/libs/shared-types/src/validators/annotation-validator.ts
+++ b/libs/shared-types/src/validators/annotation-validator.ts
@@ -172,7 +172,10 @@ export function validateMultiPolygonCoordinates(coordinates: unknown): boolean {
 /**
  * Validates geometry coordinates based on type
  */
-export function validateGeometryCoordinates(geometry: any): boolean {
+export function validateGeometryCoordinates(geometry: { type: string; coordinates: unknown } | null): boolean {
+  if (!geometry) {
+    return false;
+  }
   switch (geometry.type) {
     case 'Point':
       return validatePointCoordinates(geometry.coordinates);

--- a/libs/tool-vault-packager/cli.py
+++ b/libs/tool-vault-packager/cli.py
@@ -141,7 +141,7 @@ def call_tool_command(tools_path: str, tool_name: str, arguments: Dict[str, Any]
         # Convert Pydantic models to dictionaries for proper JSON serialization
         if hasattr(result, "model_dump"):
             # Pydantic v2 - use mode='json' to handle datetime serialization
-            result_data = result.model_dump(mode='json')
+            result_data = result.model_dump(mode="json")
         elif hasattr(result, "dict"):
             # Pydantic v1
             result_data = result.dict()

--- a/libs/tool-vault-packager/discovery.py
+++ b/libs/tool-vault-packager/discovery.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Protocol, Union, cast, get_type_hints
 
 from debrief.types.tools import (
+    DebriefCommand,
     GitHistoryEntry,
     GlobalToolIndexModel,
     JSONSchemaType,
@@ -16,7 +17,6 @@ from debrief.types.tools import (
     ToolCategory,
     ToolIndexNode,
     ToolMetadataModel,
-    DebriefCommand,
 )
 
 
@@ -507,7 +507,9 @@ def discover_tool_nodes(tools_dir: Path) -> List[ToolIndexNode]:
             ]
 
             if len(public_functions) != 1:
-                print(f"Warning: Tool '{tool_name}' must have exactly one public function, skipping")
+                print(
+                    f"Warning: Tool '{tool_name}' must have exactly one public function, skipping"
+                )
                 continue
 
             func_name, func = public_functions[0]
@@ -581,11 +583,7 @@ def discover_tool_nodes(tools_dir: Path) -> List[ToolIndexNode]:
             # This is a category folder - recurse
             children = discover_tool_nodes(item)
             if children:  # Only add category if it has children
-                nodes.append(ToolCategory(
-                    type="category",
-                    name=item.name,
-                    children=children
-                ))
+                nodes.append(ToolCategory(type="category", name=item.name, children=children))
 
     return nodes
 
@@ -799,7 +797,7 @@ def generate_tool_list_response_tree(tools_dir: Path) -> GlobalToolIndexModel:
         root=root_nodes,
         version="1.0.0",
         description="ToolVault packaged tools with hierarchical structure",
-        packageInfo=None
+        packageInfo=None,
     )
 
 

--- a/libs/tool-vault-packager/discovery.py
+++ b/libs/tool-vault-packager/discovery.py
@@ -16,7 +16,7 @@ from debrief.types.tools import (
     ToolCategory,
     ToolIndexNode,
     ToolMetadataModel,
-    ToolVaultCommand,
+    DebriefCommand,
 )
 
 
@@ -539,8 +539,8 @@ def discover_tool_nodes(tools_dir: Path) -> List[ToolIndexNode]:
                     # Create JSONSchemaProperty from the remaining schema
                     json_properties[param_name] = JSONSchemaProperty(**param_copy)
 
-            # Get the ToolVaultCommand schema as the output schema
-            command_schema = ToolVaultCommand.model_json_schema()
+            # Get the DebriefCommand schema as the output schema
+            command_schema = DebriefCommand.model_json_schema()
 
             # Get relative path from tools root for nested categories
             # Calculate relative path from tools root
@@ -841,8 +841,8 @@ def generate_tool_list_response(tools: List[ToolMetadata]) -> GlobalToolIndexMod
                 # Create JSONSchemaProperty from the remaining schema
                 json_properties[param_name] = JSONSchemaProperty(**param_copy)
 
-        # Get the ToolVaultCommand schema as the output schema
-        command_schema = ToolVaultCommand.model_json_schema()
+        # Get the DebriefCommand schema as the output schema
+        command_schema = DebriefCommand.model_json_schema()
 
         # Validate and report schema compatibility - using enhanced JSONSchema model
         valid_jsonschema_fields = {
@@ -906,7 +906,7 @@ def generate_tool_list_response(tools: List[ToolMetadata]) -> GlobalToolIndexMod
             print(f"   Valid JSONSchema fields are: {sorted(valid_jsonschema_fields)}")
             print(f"   Tool output schema: {command_schema}")
             print("\n💡 To fix this, update the JSONSchema model to support these fields")
-            print("   or modify the ToolVaultCommand schema to only use valid fields.")
+            print("   or modify the DebriefCommand schema to only use valid fields.")
             raise ToolDiscoveryError(
                 f"Tool '{tool.name}' has incompatible output schema. "
                 f"Invalid fields: {sorted(invalid_fields)}. "

--- a/libs/tool-vault-packager/packager.py
+++ b/libs/tool-vault-packager/packager.py
@@ -13,7 +13,7 @@ from debrief.types.tools import (
     ToolFilesCollection,
     ToolIndexModel,
     ToolStatsModel,
-    ToolVaultCommand,
+    DebriefCommand,
 )
 
 try:
@@ -511,7 +511,7 @@ def package_toolvault(
                 )
 
             # Always expose the ToolVault command output schema for reference
-            output_schema = ToolVaultCommand.model_json_schema()
+            output_schema = DebriefCommand.model_json_schema()
             output_schema_path = schemas_dir / "output_schema.json"
             with open(output_schema_path, "w") as f:
                 json.dump(output_schema, f, indent=2)

--- a/libs/tool-vault-packager/packager.py
+++ b/libs/tool-vault-packager/packager.py
@@ -8,12 +8,12 @@ import zipapp
 from pathlib import Path
 
 from debrief.types.tools import (
+    DebriefCommand,
     SampleInputReference,
     ToolFileReference,
     ToolFilesCollection,
     ToolIndexModel,
     ToolStatsModel,
-    DebriefCommand,
 )
 
 try:

--- a/libs/tool-vault-packager/server.py
+++ b/libs/tool-vault-packager/server.py
@@ -102,16 +102,12 @@ class ToolVaultServer:
                     with zipfile.ZipFile(pyz_path, "r") as archive:
                         index_content = archive.read("index.json").decode("utf-8")
                         self.index_data = json.loads(index_content)
-                        print(
-                            "Loaded pre-built index from package"
-                        )
+                        print("Loaded pre-built index from package")
                 else:
                     # Fallback for other archive modes
                     with open("index.json", "r") as f:
                         self.index_data = json.load(f)
-                        print(
-                            "Loaded pre-built index from file"
-                        )
+                        print("Loaded pre-built index from file")
 
                 # In production mode, we don't run discover_tools() at all!
                 # Tools are lazy-loaded on-demand from index metadata
@@ -198,11 +194,13 @@ class ToolVaultServer:
 
         try:
             import importlib
+
             module = importlib.import_module(module_path)
             function = getattr(module, function_name)
 
             # Detect Pydantic parameter model from function signature
             from discovery import PydanticModelType, detect_pydantic_parameter_model
+
             pydantic_model_raw = detect_pydantic_parameter_model(function, module)
 
             if not pydantic_model_raw:
@@ -223,11 +221,12 @@ class ToolVaultServer:
                     parameters[param_name] = {
                         "type": param_info.get("type", "any"),
                         "description": param_info.get("description", ""),
-                        "required": param_name in input_schema.get("required", [])
+                        "required": param_name in input_schema.get("required", []),
                     }
 
             # Create ToolMetadata object with required fields
             from discovery import ToolMetadata
+
             tool_metadata = ToolMetadata(
                 name=tool_name,
                 function=function,
@@ -236,7 +235,7 @@ class ToolVaultServer:
                 return_type="dict",  # Default assumption for output
                 module_path=module_path,
                 tool_dir=str(Path("tools") / tool_name),
-                pydantic_model=pydantic_model
+                pydantic_model=pydantic_model,
             )
 
             # Cache it
@@ -246,6 +245,7 @@ class ToolVaultServer:
         except Exception as e:
             print(f"Error lazy-loading tool '{tool_name}': {e}")
             import traceback
+
             traceback.print_exc()
             return None
 

--- a/libs/tool-vault-packager/server.py
+++ b/libs/tool-vault-packager/server.py
@@ -408,7 +408,7 @@ class ToolVaultServer:
 
                 # Handle different result types
                 if hasattr(result, "model_dump"):
-                    # It's a Pydantic model (like ToolVaultCommand)
+                    # It's a Pydantic model (like DebriefCommand)
                     command_result = result.model_dump()
                 elif isinstance(result, dict) and "command" in result:
                     # It's already a dict with command structure

--- a/libs/tool-vault-packager/test/tiered_tools/category1/subcategory1/deep_tool_1/execute.py
+++ b/libs/tool-vault-packager/test/tiered_tools/category1/subcategory1/deep_tool_1/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field
 
 
@@ -19,7 +19,7 @@ class WordCountParameters(BaseModel):
     )
 
 
-def word_count(params: WordCountParameters) -> ToolVaultCommand:
+def word_count(params: WordCountParameters) -> DebriefCommand:
     """
     Count the number of words in a given block of text.
 
@@ -31,7 +31,7 @@ def word_count(params: WordCountParameters) -> ToolVaultCommand:
         params: WordCountParameters object with text field
 
     Returns:
-        ToolVaultCommand: ToolVault command object with word count result
+        DebriefCommand: ToolVault command object with word count result
 
     Examples:
         >>> params = WordCountParameters(text="Hello world")

--- a/libs/tool-vault-packager/test/tiered_tools/category1/subcategory1/deep_tool_1/execute.py
+++ b/libs/tool-vault-packager/test/tiered_tools/category1/subcategory1/deep_tool_1/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, ShowTextCommand
 from pydantic import BaseModel, Field
 
 

--- a/libs/tool-vault-packager/test/tiered_tools/category1/tool_at_level_2/execute.py
+++ b/libs/tool-vault-packager/test/tiered_tools/category1/tool_at_level_2/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field
 
 
@@ -19,7 +19,7 @@ class WordCountParameters(BaseModel):
     )
 
 
-def word_count(params: WordCountParameters) -> ToolVaultCommand:
+def word_count(params: WordCountParameters) -> DebriefCommand:
     """
     Count the number of words in a given block of text.
 
@@ -31,7 +31,7 @@ def word_count(params: WordCountParameters) -> ToolVaultCommand:
         params: WordCountParameters object with text field
 
     Returns:
-        ToolVaultCommand: ToolVault command object with word count result
+        DebriefCommand: ToolVault command object with word count result
 
     Examples:
         >>> params = WordCountParameters(text="Hello world")

--- a/libs/tool-vault-packager/test/tiered_tools/category1/tool_at_level_2/execute.py
+++ b/libs/tool-vault-packager/test/tiered_tools/category1/tool_at_level_2/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, ShowTextCommand
 from pydantic import BaseModel, Field
 
 

--- a/libs/tool-vault-packager/test/tiered_tools/category2/another_tool/execute.py
+++ b/libs/tool-vault-packager/test/tiered_tools/category2/another_tool/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field
 
 
@@ -19,7 +19,7 @@ class WordCountParameters(BaseModel):
     )
 
 
-def word_count(params: WordCountParameters) -> ToolVaultCommand:
+def word_count(params: WordCountParameters) -> DebriefCommand:
     """
     Count the number of words in a given block of text.
 
@@ -31,7 +31,7 @@ def word_count(params: WordCountParameters) -> ToolVaultCommand:
         params: WordCountParameters object with text field
 
     Returns:
-        ToolVaultCommand: ToolVault command object with word count result
+        DebriefCommand: ToolVault command object with word count result
 
     Examples:
         >>> params = WordCountParameters(text="Hello world")

--- a/libs/tool-vault-packager/test/tiered_tools/category2/another_tool/execute.py
+++ b/libs/tool-vault-packager/test/tiered_tools/category2/another_tool/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, ShowTextCommand
 from pydantic import BaseModel, Field
 
 

--- a/libs/tool-vault-packager/tools/feature-management/toggle_first_feature_color/execute.py
+++ b/libs/tool-vault-packager/tools/feature-management/toggle_first_feature_color/execute.py
@@ -3,7 +3,7 @@
 from debrief.types.features import DebriefFeatureCollection
 from debrief.types.tools import (
     ShowTextCommand,
-    ToolVaultCommand,
+    DebriefCommand,
     UpdateFeaturesCommand,
 )
 from pydantic import BaseModel, Field, ValidationError
@@ -30,7 +30,7 @@ class ToggleFirstFeatureColorParameters(BaseModel):
     )
 
 
-def toggle_first_feature_color(params: ToggleFirstFeatureColorParameters) -> ToolVaultCommand:
+def toggle_first_feature_color(params: ToggleFirstFeatureColorParameters) -> DebriefCommand:
     """
     Toggle the color property of the first feature in a GeoJSON FeatureCollection.
 
@@ -44,7 +44,7 @@ def toggle_first_feature_color(params: ToggleFirstFeatureColorParameters) -> Too
         params: ToggleFirstFeatureColorParameters containing feature_collection
 
     Returns:
-        ToolVaultCommand: Command to update the modified feature (not replace entire collection)
+        DebriefCommand: Command to update the modified feature (not replace entire collection)
 
     Examples:
         >>> from pydantic import ValidationError

--- a/libs/tool-vault-packager/tools/feature-management/toggle_first_feature_color/execute.py
+++ b/libs/tool-vault-packager/tools/feature-management/toggle_first_feature_color/execute.py
@@ -2,8 +2,8 @@
 
 from debrief.types.features import DebriefFeatureCollection
 from debrief.types.tools import (
-    ShowTextCommand,
     DebriefCommand,
+    ShowTextCommand,
     UpdateFeaturesCommand,
 )
 from pydantic import BaseModel, Field, ValidationError
@@ -142,11 +142,10 @@ def toggle_first_feature_color(params: ToggleFirstFeatureColorParameters) -> Deb
 
         # Return UpdateFeaturesCommand with the validated feature
         # We need to serialize with aliases and re-parse to get proper JSON keys
-        feature_json = validated_feature.model_dump(by_alias=True, mode='json')
+        feature_json = validated_feature.model_dump(by_alias=True, mode="json")
 
         return UpdateFeaturesCommand.model_construct(
-            command="updateFeatures",
-            payload=[feature_json]
+            command="updateFeatures", payload=[feature_json]
         )
 
     except ValidationError as e:

--- a/libs/tool-vault-packager/tools/selection/fit_to_selection/execute.py
+++ b/libs/tool-vault-packager/tools/selection/fit_to_selection/execute.py
@@ -5,7 +5,7 @@ from typing import List
 # Use hierarchical imports from shared-types
 from debrief.types.features import DebriefFeature
 from debrief.types.states.viewport_state import ViewportState
-from debrief.types.tools import SetViewportCommand, ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import SetViewportCommand, ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field
 
 
@@ -33,7 +33,7 @@ class FitToSelectionParameters(BaseModel):
     )
 
 
-def fit_to_selection(params: FitToSelectionParameters) -> ToolVaultCommand:
+def fit_to_selection(params: FitToSelectionParameters) -> DebriefCommand:
     """
     Calculate bounds of features and set viewport to fit them.
 

--- a/libs/tool-vault-packager/tools/selection/fit_to_selection/execute.py
+++ b/libs/tool-vault-packager/tools/selection/fit_to_selection/execute.py
@@ -5,7 +5,7 @@ from typing import List
 # Use hierarchical imports from shared-types
 from debrief.types.features import DebriefFeature
 from debrief.types.states.viewport_state import ViewportState
-from debrief.types.tools import SetViewportCommand, ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, SetViewportCommand, ShowTextCommand
 from pydantic import BaseModel, Field
 
 

--- a/libs/tool-vault-packager/tools/selection/select_all_visible/execute.py
+++ b/libs/tool-vault-packager/tools/selection/select_all_visible/execute.py
@@ -6,7 +6,7 @@ from typing import Any, List, Union
 from debrief.types.features import DebriefFeatureCollection
 from debrief.types.states.selection_state import SelectionState
 from debrief.types.states.viewport_state import ViewportState
-from debrief.types.tools import SetSelectionCommand, ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import SetSelectionCommand, ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field, field_validator
 
 
@@ -57,7 +57,7 @@ class SelectAllVisibleParameters(BaseModel):
         return v
 
 
-def select_all_visible(params: SelectAllVisibleParameters) -> ToolVaultCommand:
+def select_all_visible(params: SelectAllVisibleParameters) -> DebriefCommand:
     """
     Select all features that are visible within the current viewport bounds.
 

--- a/libs/tool-vault-packager/tools/selection/select_all_visible/execute.py
+++ b/libs/tool-vault-packager/tools/selection/select_all_visible/execute.py
@@ -6,7 +6,7 @@ from typing import Any, List, Union
 from debrief.types.features import DebriefFeatureCollection
 from debrief.types.states.selection_state import SelectionState
 from debrief.types.states.viewport_state import ViewportState
-from debrief.types.tools import SetSelectionCommand, ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, SetSelectionCommand, ShowTextCommand
 from pydantic import BaseModel, Field, field_validator
 
 

--- a/libs/tool-vault-packager/tools/selection/select_feature_start_time/execute.py
+++ b/libs/tool-vault-packager/tools/selection/select_feature_start_time/execute.py
@@ -6,7 +6,7 @@ from typing import List
 # Use hierarchical imports from shared-types
 from debrief.types.features import DebriefFeature
 from debrief.types.states import TimeState
-from debrief.types.tools import SetTimeStateCommand, ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import SetTimeStateCommand, ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field
 
 
@@ -42,7 +42,7 @@ class SelectFeatureStartTimeParameters(BaseModel):
     )
 
 
-def select_feature_start_time(params: SelectFeatureStartTimeParameters) -> ToolVaultCommand:
+def select_feature_start_time(params: SelectFeatureStartTimeParameters) -> DebriefCommand:
     """
     Set TimeState current to the earliest timestamp from any feature.
 

--- a/libs/tool-vault-packager/tools/selection/select_feature_start_time/execute.py
+++ b/libs/tool-vault-packager/tools/selection/select_feature_start_time/execute.py
@@ -6,7 +6,7 @@ from typing import List
 # Use hierarchical imports from shared-types
 from debrief.types.features import DebriefFeature
 from debrief.types.states import TimeState
-from debrief.types.tools import SetTimeStateCommand, ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, SetTimeStateCommand, ShowTextCommand
 from pydantic import BaseModel, Field
 
 

--- a/libs/tool-vault-packager/tools/text/word_count/execute.py
+++ b/libs/tool-vault-packager/tools/text/word_count/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field
 
 
@@ -19,7 +19,7 @@ class WordCountParameters(BaseModel):
     )
 
 
-def word_count(params: WordCountParameters) -> ToolVaultCommand:
+def word_count(params: WordCountParameters) -> DebriefCommand:
     """
     Count the number of words in a given block of text.
 
@@ -31,7 +31,7 @@ def word_count(params: WordCountParameters) -> ToolVaultCommand:
         params: WordCountParameters object with text field
 
     Returns:
-        ToolVaultCommand: ToolVault command object with word count result
+        DebriefCommand: ToolVault command object with word count result
 
     Examples:
         >>> params = WordCountParameters(text="Hello world")

--- a/libs/tool-vault-packager/tools/text/word_count/execute.py
+++ b/libs/tool-vault-packager/tools/text/word_count/execute.py
@@ -1,6 +1,6 @@
 """Word counting tool for text analysis."""
 
-from debrief.types.tools import ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, ShowTextCommand
 from pydantic import BaseModel, Field
 
 

--- a/libs/tool-vault-packager/tools/track-analysis/track_speed_filter/execute.py
+++ b/libs/tool-vault-packager/tools/track-analysis/track_speed_filter/execute.py
@@ -3,7 +3,7 @@
 import math
 
 from debrief.types.features import DebriefTrackFeature
-from debrief.types.tools import ShowDataCommand, ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import ShowDataCommand, ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -42,7 +42,7 @@ class TrackSpeedFilterParameters(BaseModel):
     )
 
 
-def track_speed_filter(params: TrackSpeedFilterParameters) -> ToolVaultCommand:
+def track_speed_filter(params: TrackSpeedFilterParameters) -> DebriefCommand:
     """
     Find timestamps where track speed equals or exceeds a minimum threshold.
 

--- a/libs/tool-vault-packager/tools/track-analysis/track_speed_filter/execute.py
+++ b/libs/tool-vault-packager/tools/track-analysis/track_speed_filter/execute.py
@@ -3,7 +3,7 @@
 import math
 
 from debrief.types.features import DebriefTrackFeature
-from debrief.types.tools import ShowDataCommand, ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, ShowDataCommand, ShowTextCommand
 from pydantic import BaseModel, Field, ValidationError
 
 

--- a/libs/tool-vault-packager/tools/track-analysis/track_speed_filter_fast/execute.py
+++ b/libs/tool-vault-packager/tools/track-analysis/track_speed_filter_fast/execute.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from debrief.types.features import DebriefTrackFeature
-from debrief.types.tools import ShowDataCommand, ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import ShowDataCommand, ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 
@@ -127,7 +127,7 @@ class TrackSpeedFilterFastParameters(BaseModel):
     )
 
 
-def track_speed_filter_fast(params: TrackSpeedFilterFastParameters) -> ToolVaultCommand:
+def track_speed_filter_fast(params: TrackSpeedFilterFastParameters) -> DebriefCommand:
     """
     Filter track timestamps using pre-calculated speeds array for fast processing.
 

--- a/libs/tool-vault-packager/tools/track-analysis/track_speed_filter_fast/execute.py
+++ b/libs/tool-vault-packager/tools/track-analysis/track_speed_filter_fast/execute.py
@@ -3,7 +3,7 @@
 from typing import List
 
 from debrief.types.features import DebriefTrackFeature
-from debrief.types.tools import ShowDataCommand, ShowTextCommand, DebriefCommand
+from debrief.types.tools import DebriefCommand, ShowDataCommand, ShowTextCommand
 from pydantic import BaseModel, Field, ValidationError, model_validator
 
 

--- a/libs/tool-vault-packager/tools/viewport/viewport_grid_generator/execute.py
+++ b/libs/tool-vault-packager/tools/viewport/viewport_grid_generator/execute.py
@@ -1,7 +1,7 @@
 """Viewport grid generator tool for maritime analysis."""
 
 from debrief.types.states.viewport_state import ViewportState
-from debrief.types.tools import AddFeaturesCommand, ShowTextCommand, ToolVaultCommand
+from debrief.types.tools import AddFeaturesCommand, ShowTextCommand, DebriefCommand
 from pydantic import BaseModel, Field, ValidationError
 
 
@@ -30,7 +30,7 @@ class ViewportGridGeneratorParameters(BaseModel):
     )
 
 
-def viewport_grid_generator(params: ViewportGridGeneratorParameters) -> ToolVaultCommand:
+def viewport_grid_generator(params: ViewportGridGeneratorParameters) -> DebriefCommand:
     """
     Generate a grid of points within a viewport area at specified intervals.
 

--- a/libs/tool-vault-packager/tools/viewport/viewport_grid_generator/execute.py
+++ b/libs/tool-vault-packager/tools/viewport/viewport_grid_generator/execute.py
@@ -1,7 +1,7 @@
 """Viewport grid generator tool for maritime analysis."""
 
 from debrief.types.states.viewport_state import ViewportState
-from debrief.types.tools import AddFeaturesCommand, ShowTextCommand, DebriefCommand
+from debrief.types.tools import AddFeaturesCommand, DebriefCommand, ShowTextCommand
 from pydantic import BaseModel, Field, ValidationError
 
 

--- a/libs/web-components/src/index.ts
+++ b/libs/web-components/src/index.ts
@@ -15,7 +15,7 @@ export { ToolExecutionProvider, useToolExecution } from './contexts/ToolExecutio
 
 // Service exports
 export { ToolParameterService } from './services/toolParameterService';
-export { ToolVaultCommandHandler } from './services/ToolVaultCommandHandler';
+export { DebriefCommandHandler } from './services/DebriefCommandHandler';
 
 // Type exports
 export type { TimeControllerProps } from './TimeController/TimeController';
@@ -47,4 +47,4 @@ export type {
   CommandHandlerOptions
 } from './services/types';
 
-export type { SpecificCommand } from './services/ToolVaultCommandHandler';
+export type { SpecificCommand } from './services/DebriefCommandHandler';

--- a/libs/web-components/src/services/DebriefCommandHandler.test.ts
+++ b/libs/web-components/src/services/DebriefCommandHandler.test.ts
@@ -1,8 +1,8 @@
 /**
- * Unit tests for ToolVaultCommandHandler service
+ * Unit tests for DebriefCommandHandler service
  */
 
-import { ToolVaultCommandHandler } from './ToolVaultCommandHandler';
+import { DebriefCommandHandler } from './DebriefCommandHandler';
 import { StateSetter } from './types';
 import {
   DebriefFeatureCollection,
@@ -114,14 +114,14 @@ const createTestTimeState = (): TimeState => ({
   end: '2024-01-01T01:00:00Z',
 });
 
-describe('ToolVaultCommandHandler', () => {
-  let handler: ToolVaultCommandHandler;
+describe('DebriefCommandHandler', () => {
+  let handler: DebriefCommandHandler;
   let mockStateSetter: MockStateSetter;
   let testFeatureCollection: DebriefFeatureCollection;
 
   beforeEach(() => {
     mockStateSetter = new MockStateSetter();
-    handler = new ToolVaultCommandHandler(mockStateSetter);
+    handler = new DebriefCommandHandler(mockStateSetter);
     testFeatureCollection = createTestFeatureCollection();
   });
 

--- a/libs/web-components/src/services/DebriefCommandHandler.ts
+++ b/libs/web-components/src/services/DebriefCommandHandler.ts
@@ -1,8 +1,8 @@
 /**
- * ToolVaultCommand Handler Service - Central command processing for plot state updates
+ * DebriefCommand Handler Service - Central command processing for plot state updates
  *
- * This service bridges the gap between tool vault command execution and plot state management,
- * providing a standardized interface for processing all 12 ToolVaultCommand types and applying
+ * This service bridges the gap between Tool Vault tool execution and Debrief plot state management,
+ * providing a standardized interface for processing all 12 DebriefCommand types and applying
  * their effects to FeatureCollections and document state.
  */
 
@@ -23,8 +23,8 @@ import { ShowDataCommand } from '@debrief/shared-types/derived/typescript/tools/
 import { ShowImageCommand } from '@debrief/shared-types/derived/typescript/tools/show_image_command';
 import { LogMessageCommand } from '@debrief/shared-types/derived/typescript/tools/log_message_command';
 
-// Base ToolVaultCommand type
-import { ToolVaultCommand } from '@debrief/shared-types/derived/typescript/tools/tool_call_response';
+// Base DebriefCommand type
+import { DebriefCommand } from '@debrief/shared-types/derived/typescript/tools/tool_call_response';
 
 import {
   StateSetter,
@@ -51,7 +51,7 @@ export type SpecificCommand =
 // CompositeCommand interface (not yet generated, so defining locally)
 interface CompositeCommand {
   command: 'composite';
-  payload: ToolVaultCommand[];
+  payload: DebriefCommand[];
 }
 
 // SetTimeStateCommand interface (seems missing from generated types)
@@ -61,9 +61,9 @@ interface SetTimeStateCommand {
 }
 
 /**
- * Main service class for processing ToolVaultCommands
+ * Main service class for processing DebriefCommands
  */
-export class ToolVaultCommandHandler {
+export class DebriefCommandHandler {
   private processors: Map<string, CommandProcessor> = new Map();
   private options: CommandHandlerOptions;
 
@@ -83,7 +83,7 @@ export class ToolVaultCommandHandler {
   }
 
   /**
-   * Process a ToolVaultCommand and update plot state
+   * Process a DebriefCommand and update plot state
    */
   public async processCommand(
     command: SpecificCommand,
@@ -509,7 +509,7 @@ class LogMessageProcessor implements CommandProcessor<LogMessageCommand> {
  * Processor for CompositeCommand (recursive command processing)
  */
 class CompositeProcessor implements CommandProcessor<CompositeCommand> {
-  constructor(private handler: ToolVaultCommandHandler) {}
+  constructor(private handler: DebriefCommandHandler) {}
 
   canHandle(command: unknown): command is CompositeCommand {
     return (command as SpecificCommand)?.command === 'composite';
@@ -521,7 +521,7 @@ class CompositeProcessor implements CommandProcessor<CompositeCommand> {
     _stateSetter: StateSetter
   ): Promise<CommandHandlerResult> {
     const commands = Array.isArray(command.payload) ? command.payload : [];
-    // Convert ToolVaultCommand[] to SpecificCommand[] by casting
+    // Convert DebriefCommand[] to SpecificCommand[] by casting
     const specificCommands = commands as SpecificCommand[];
     const results = await this.handler.processCommands(specificCommands, featureCollection);
 

--- a/libs/web-components/src/services/index.ts
+++ b/libs/web-components/src/services/index.ts
@@ -5,7 +5,7 @@
 
 // Service exports
 export { ToolParameterService } from './toolParameterService';
-export { ToolVaultCommandHandler } from './ToolVaultCommandHandler';
+export { DebriefCommandHandler } from './DebriefCommandHandler';
 
 // Service type exports
 export type {
@@ -24,4 +24,4 @@ export type {
   CommandHandlerOptions
 } from './types';
 
-export type { SpecificCommand } from './ToolVaultCommandHandler';
+export type { SpecificCommand } from './DebriefCommandHandler';

--- a/libs/web-components/src/services/types.ts
+++ b/libs/web-components/src/services/types.ts
@@ -1,5 +1,5 @@
 /**
- * Service-specific TypeScript interfaces for ToolVaultCommandHandler
+ * Service-specific TypeScript interfaces for DebriefCommandHandler
  */
 
 import {
@@ -11,7 +11,7 @@ import {
 } from '@debrief/shared-types';
 
 /**
- * State setter interface for dependency injection into ToolVaultCommandHandler
+ * State setter interface for dependency injection into DebriefCommandHandler
  * Provides a unified interface for document state updates
  */
 export interface StateSetter {
@@ -82,7 +82,7 @@ export interface CommandProcessor<TCommand = unknown> {
 }
 
 /**
- * Configuration options for the ToolVaultCommandHandler
+ * Configuration options for the DebriefCommandHandler
  */
 export interface CommandHandlerOptions {
   /** Enable rollback capability for failed composite commands */

--- a/libs/web-components/src/stories/DebriefCommandHandler.stories.tsx
+++ b/libs/web-components/src/stories/DebriefCommandHandler.stories.tsx
@@ -1,13 +1,13 @@
 /**
- * Storybook stories for ToolVaultCommandHandler service demonstration
+ * Storybook stories for DebriefCommandHandler service demonstration
  *
- * These stories provide interactive examples of all 12 ToolVaultCommand types,
+ * These stories provide interactive examples of all 12 DebriefCommand types,
  * showing before/after state changes and command processing results.
  */
 
 import type { Meta, StoryObj } from '@storybook/react';
 import React, { useState, useCallback, useMemo } from 'react';
-import { ToolVaultCommandHandler } from '../services/ToolVaultCommandHandler';
+import { DebriefCommandHandler } from '../services/DebriefCommandHandler';
 import { StateSetter } from '../services/types';
 import {
   DebriefFeatureCollection,
@@ -258,7 +258,7 @@ const sampleCommands = {
 };
 
 // Interactive Story Component
-const ToolVaultCommandHandlerDemo: React.FC = () => {
+const DebriefCommandHandlerDemo: React.FC = () => {
   const [featureCollection, setFeatureCollection] = useState<DebriefFeatureCollection>(
     createSampleFeatureCollection()
   );
@@ -307,7 +307,7 @@ const ToolVaultCommandHandlerDemo: React.FC = () => {
     },
   }), []);
 
-  const handler = useMemo(() => new ToolVaultCommandHandler(stateSetter), [stateSetter]);
+  const handler = useMemo(() => new DebriefCommandHandler(stateSetter), [stateSetter]);
 
   const executeCommand = useCallback(async () => {
     setIsProcessing(true);
@@ -344,7 +344,7 @@ const ToolVaultCommandHandlerDemo: React.FC = () => {
 
   return (
     <div style={{ padding: '20px', fontFamily: 'Arial, sans-serif' }}>
-      <h2>ToolVaultCommand Handler Interactive Demo</h2>
+      <h2>DebriefCommand Handler Interactive Demo</h2>
 
       <div style={{ marginBottom: '20px' }}>
         <h3>Current State Display</h3>
@@ -511,17 +511,17 @@ const ToolVaultCommandHandlerDemo: React.FC = () => {
 };
 
 // Storybook configuration
-const meta: Meta<typeof ToolVaultCommandHandlerDemo> = {
-  title: 'Services/ToolVaultCommandHandler',
-  component: ToolVaultCommandHandlerDemo,
+const meta: Meta<typeof DebriefCommandHandlerDemo> = {
+  title: 'Services/DebriefCommandHandler',
+  component: DebriefCommandHandlerDemo,
   parameters: {
     layout: 'fullscreen',
     docs: {
       description: {
         component: `
-# ToolVaultCommand Handler Service
+# DebriefCommand Handler Service
 
-This interactive demo showcases the ToolVaultCommandHandler service, which processes all 12 types of ToolVaultCommands and updates plot state accordingly.
+This interactive demo showcases the DebriefCommandHandler service, which processes all 12 types of DebriefCommands and updates plot state accordingly.
 
 ## Features Demonstrated
 
@@ -561,14 +561,14 @@ The demo uses real maritime GeoJSON data including vessel tracks, navigation poi
 };
 
 export default meta;
-type Story = StoryObj<typeof ToolVaultCommandHandlerDemo>;
+type Story = StoryObj<typeof DebriefCommandHandlerDemo>;
 
 export const Interactive: Story = {
-  render: () => <ToolVaultCommandHandlerDemo />,
+  render: () => <DebriefCommandHandlerDemo />,
 };
 
 export const FeatureManagementCommands: Story = {
-  render: () => <ToolVaultCommandHandlerDemo />,
+  render: () => <DebriefCommandHandlerDemo />,
   parameters: {
     docs: {
       description: {
@@ -579,7 +579,7 @@ export const FeatureManagementCommands: Story = {
 };
 
 export const StateManagementCommands: Story = {
-  render: () => <ToolVaultCommandHandlerDemo />,
+  render: () => <DebriefCommandHandlerDemo />,
   parameters: {
     docs: {
       description: {
@@ -590,7 +590,7 @@ export const StateManagementCommands: Story = {
 };
 
 export const UserInterfaceCommands: Story = {
-  render: () => <ToolVaultCommandHandlerDemo />,
+  render: () => <DebriefCommandHandlerDemo />,
   parameters: {
     docs: {
       description: {
@@ -601,7 +601,7 @@ export const UserInterfaceCommands: Story = {
 };
 
 export const CompositeCommandExample: Story = {
-  render: () => <ToolVaultCommandHandlerDemo />,
+  render: () => <DebriefCommandHandlerDemo />,
   parameters: {
     docs: {
       description: {


### PR DESCRIPTION
## Summary

Renamed `ToolVaultCommand` to `DebriefCommand` throughout the codebase to accurately reflect that these commands trigger state changes in Debrief, not in the Tool Vault. This terminology fix improves developer clarity and aligns naming with the actual data flow direction.

**Rationale**: The current naming `ToolVaultCommand` suggests the Tool Vault is the target, but these commands actually flow FROM Tool Vault TO Debrief to modify plot state. The new name `DebriefCommand` correctly identifies Debrief as the target receiving state modifications.

## Changes

### Phase 1: Pydantic Models (libs/shared-types)
- Renamed `ToolVaultCommand` → `DebriefCommand` in `tool_call_response.py`
- Updated all command subclasses to inherit from `DebriefCommand`
- Updated helper functions and docstrings
- Regenerated TypeScript types and JSON schemas

### Phase 2: Web Components (libs/web-components)
- Renamed service files:
  - `ToolVaultCommandHandler.ts` → `DebriefCommandHandler.ts`
  - `ToolVaultCommandHandler.test.ts` → `DebriefCommandHandler.test.ts`
  - `ToolVaultCommandHandler.stories.tsx` → `DebriefCommandHandler.stories.tsx`
- Updated class name and all type references
- Updated service exports

### Phase 3: VS Code Extension (apps/vs-code)
- Updated `globalController.ts` with new handler name
- Renamed methods: `processToolVaultCommands` → `processDebriefCommands`
- Updated type guards and helper methods
- Updated provider references

### Phase 4: Tool Vault Packager (libs/tool-vault-packager)
- Updated all Python imports across 14 tool files
- Updated core files: `server.py`, `discovery.py`, `packager.py`
- Fixed import ordering per ruff standards

## Testing

- ✅ All tests passing (122 tests in web-components, all shared-types tests)
- ✅ TypeScript compilation successful across all packages
- ✅ Linting and static analysis clean
- ✅ Pre-push hook validation passed
- ✅ Build artifacts generated successfully

## Files Changed
29 files modified across all packages (shared-types, web-components, vs-code, tool-vault-packager)

Fixes #209