### PR TITLE
feat: Phase 1 MCP Endpoint Implementation for LLM Integration

### DIFF
--- a/apps/vs-code/package.json
+++ b/apps/vs-code/package.json
@@ -14,12 +14,13 @@
     "copy-webcomponents": "cp ../../libs/web-components/dist/vanilla/index.js media/web-components.js && cp ../../libs/web-components/dist/vanilla/index.css media/web-components.css",
     "copy-schemas": "mkdir -p schemas && cp -r ../../libs/shared-types/derived/json-schema/* schemas/",
     "bundle-python-wheel": "mkdir -p python && cp ../../libs/shared-types/dist/python/*.whl python/ 2>/dev/null || echo 'No Python wheel found - run pnpm build:shared-types first'",
-    "compile": "pnpm esbuild-base --sourcemap && pnpm copy-webcomponents && pnpm copy-schemas && pnpm bundle-python-wheel",
+    "generate-mcp-tools": "mkdir -p dist && ts-node scripts/generate-mcp-tools.ts",
+    "compile": "pnpm esbuild-base --sourcemap && pnpm copy-webcomponents && pnpm copy-schemas && pnpm bundle-python-wheel && pnpm generate-mcp-tools",
     "build": "pnpm vscode:prepublish && vsce package --no-dependencies",
     "build:docker": "pnpm build && cp vs-code-0.0.1.vsix ../../",
     "watch": "pnpm esbuild-base --sourcemap --watch",
     "dev": "pnpm copy-webcomponents && pnpm watch",
-    "vscode:prepublish": "pnpm esbuild-base --minify && pnpm copy-webcomponents && pnpm copy-schemas && pnpm bundle-python-wheel",
+    "vscode:prepublish": "pnpm esbuild-base --minify && pnpm copy-webcomponents && pnpm copy-schemas && pnpm bundle-python-wheel && pnpm generate-mcp-tools",
     "docker:build": "docker build -t debrief-vscode-local --build-arg GITHUB_SHA=local --build-arg PR_NUMBER=dev -f Dockerfile ../..",
     "docker:run": "docker run -p 8080:8080 -p 60123:60123 -p 60124:60124 debrief-vscode-local",
     "docker:stop": "docker stop debrief-vscode-local && docker rm debrief-vscode-local",
@@ -199,6 +200,7 @@
     "@debrief/shared-types": "workspace:^1.0.0",
     "@eslint/js": "^9.34.0",
     "@playwright/test": "^1.55.1",
+    "@types/express": "^5.0.3",
     "@types/jest": "^29.5.14",
     "@types/node": "18.x",
     "@types/vscode": "^1.74.0",
@@ -210,12 +212,14 @@
     "eslint": "^9.34.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.4.1",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9.4",
     "typescript-eslint": "^8.42.0"
   },
   "dependencies": {
     "@debrief/web-components": "workspace:^1.0.0",
     "@vscode/codicons": "^0.0.40",
+    "express": "^5.1.0",
     "leaflet": "^1.9.4",
     "ws": "^8.14.2"
   }

--- a/apps/vs-code/scripts/generate-mcp-tools.ts
+++ b/apps/vs-code/scripts/generate-mcp-tools.ts
@@ -1,0 +1,186 @@
+/**
+ * Generate MCP tool index for Debrief State Server
+ *
+ * This script generates a JSON file containing tool definitions
+ * for the Model Context Protocol (MCP) implementation.
+ * The tools expose Debrief plot manipulation capabilities to LLM clients.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface McpTool {
+    name: string;
+    description: string;
+    inputSchema: {
+        type: string;
+        properties: Record<string, unknown>;
+        required?: string[];
+    };
+}
+
+interface McpToolIndex {
+    tools: McpTool[];
+}
+
+/**
+ * Define Debrief State Server MCP tools
+ */
+const tools: McpTool[] = [
+    {
+        name: 'debrief_get_selection',
+        description: 'Get the currently selected feature IDs from a Debrief plot',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file (e.g., "mission1.plot.json"). If omitted and only one plot is open, it will be used automatically.'
+                }
+            }
+        }
+    },
+    {
+        name: 'debrief_get_features',
+        description: 'Get the complete GeoJSON FeatureCollection from a Debrief plot, including all tracks, points, and annotations',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file. If omitted and only one plot is open, it will be used automatically.'
+                }
+            }
+        }
+    },
+    {
+        name: 'debrief_apply_command',
+        description: 'Apply a DebriefCommand to update the plot state. This can update the FeatureCollection, modify features, or trigger plot operations.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                command: {
+                    type: 'object',
+                    description: 'The DebriefCommand object containing the operation to perform and its parameters'
+                },
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file. If omitted and only one plot is open, it will be used automatically.'
+                }
+            },
+            required: ['command']
+        }
+    },
+    {
+        name: 'debrief_get_time',
+        description: 'Get the current time state (current time, start time, end time) for a Debrief plot',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file. If omitted and only one plot is open, it will be used automatically.'
+                }
+            }
+        }
+    },
+    {
+        name: 'debrief_set_time',
+        description: 'Set the time state (current time, start time, end time) for a Debrief plot. Useful for temporal analysis and time-based filtering.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                timeState: {
+                    type: 'object',
+                    description: 'TimeState object with "current", "start", and "end" properties (all ISO 8601 timestamp strings)',
+                    properties: {
+                        current: {
+                            type: 'string',
+                            description: 'Current time (ISO 8601 format)'
+                        },
+                        start: {
+                            type: 'string',
+                            description: 'Start time of the temporal range (ISO 8601 format)'
+                        },
+                        end: {
+                            type: 'string',
+                            description: 'End time of the temporal range (ISO 8601 format)'
+                        }
+                    }
+                },
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file. If omitted and only one plot is open, it will be used automatically.'
+                }
+            },
+            required: ['timeState']
+        }
+    },
+    {
+        name: 'debrief_get_viewport',
+        description: 'Get the current viewport bounds (geographic bounding box) for a Debrief plot map',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file. If omitted and only one plot is open, it will be used automatically.'
+                }
+            }
+        }
+    },
+    {
+        name: 'debrief_set_viewport',
+        description: 'Set the viewport bounds for a Debrief plot map. This pans and zooms the map to show the specified geographic area.',
+        inputSchema: {
+            type: 'object',
+            properties: {
+                viewportState: {
+                    type: 'object',
+                    description: 'ViewportState object with "bounds" property (array of 4 numbers: [west, south, east, north])',
+                    properties: {
+                        bounds: {
+                            type: 'array',
+                            description: 'Geographic bounding box as [west, south, east, north] in decimal degrees',
+                            items: {
+                                type: 'number'
+                            },
+                            minItems: 4,
+                            maxItems: 4
+                        }
+                    }
+                },
+                filename: {
+                    type: 'string',
+                    description: 'Optional filename of the plot file. If omitted and only one plot is open, it will be used automatically.'
+                }
+            },
+            required: ['viewportState']
+        }
+    }
+];
+
+/**
+ * Generate and write the MCP tool index
+ */
+function generateToolIndex(): void {
+    const toolIndex: McpToolIndex = { tools };
+
+    // Output path relative to compiled dist directory
+    const outputDir = path.join(__dirname, '..', 'dist');
+    const outputPath = path.join(outputDir, 'mcp-tools.json');
+
+    // Ensure output directory exists
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+    }
+
+    // Write tool index
+    fs.writeFileSync(outputPath, JSON.stringify(toolIndex, null, 2), 'utf-8');
+
+    console.warn(`✅ Generated MCP tool index: ${outputPath}`);
+    console.warn(`   ${tools.length} tools defined`);
+}
+
+// Run generation
+generateToolIndex();

--- a/apps/vs-code/workspace/tests/debrief_api.py
+++ b/apps/vs-code/workspace/tests/debrief_api.py
@@ -1,22 +1,20 @@
 """
-Debrief WebSocket Bridge - Python Client API (Simplified Version)
+Debrief MCP Client - Python Client API
 
 This module provides a Python interface to communicate with the Debrief VS Code extension
-through WebSocket messages. It allows Python scripts to interact with open Debrief plots.
+through the Model Context Protocol (MCP) HTTP endpoint. It allows Python scripts to interact with open Debrief plots.
 """
 
 import json
 import logging
-import threading
-import atexit
 import sys
-from typing import Optional, Dict, Any, List, Union
+from typing import Optional, Dict, Any, List
 
 try:
-    import websocket
+    import requests
 except ImportError:
     raise ImportError(
-        "websocket-client library is required. Install it with: pip install websocket-client"
+        "requests library is required. Install it with: pip install requests"
     )
 
 # Import State classes from the debrief-types package
@@ -31,645 +29,374 @@ except ImportError as e:
 
 class DebriefAPIError(Exception):
     """Exception raised for errors in the Debrief API communication."""
-    
-    def __init__(self, message: str, code: Optional[Union[int, str]] = None):
+
+    def __init__(self, message: str, code: Optional[int | str] = None):
         super().__init__(message)
         self.code = code
 
 
+class DebriefMCPClient:
+    """HTTP MCP client for communicating with Debrief VS Code extension."""
 
-class DebriefWebSocketClient:
-    """Singleton WebSocket client for communicating with Debrief VS Code extension."""
-    
-    _instance: Optional['DebriefWebSocketClient'] = None
-    _lock = threading.Lock()
-    
-    def __new__(cls) -> 'DebriefWebSocketClient':
+    _instance: Optional['DebriefMCPClient'] = None
+
+    def __new__(cls) -> 'DebriefMCPClient':
         if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = super().__new__(cls)
+            cls._instance = super().__new__(cls)
         return cls._instance
-    
+
     def __init__(self):
         if hasattr(self, '_initialized'):
             return
-            
+
         self._initialized = True
-        self.url = "ws://localhost:60123"
-        self.ws: Optional[websocket.WebSocket] = None
-        self.connected = False
+        self.base_url = "http://localhost:60123"
+        self.mcp_url = f"{self.base_url}/mcp"
+        self._request_id = 0
+        self.session = requests.Session()
+        self.session.headers.update({"Content-Type": "application/json"})
         self.logger = logging.getLogger(__name__)
-        
-        # Register cleanup
-        atexit.register(self.cleanup)
-    
-    def connect(self) -> None:
+
+    def _call_mcp(self, method: str, params: Optional[Dict[str, Any]] = None) -> Any:
         """
-        Establish connection to the WebSocket server.
-        
-        Returns:
-            None: Method returns nothing but raises DebriefAPIError on connection failure
-        
-        Raises:
-            DebriefAPIError: When connection to WebSocket server fails
-        """
-        if self.connected and self.ws:
-            return
-            
-        try:
-            self.logger.info("Connecting to Debrief...")
-            self.ws = websocket.create_connection(self.url, timeout=10)
-            self.connected = True
-            self.logger.info("Connected successfully!")
-            
-            # Read the welcome message
-            try:
-                welcome = self.ws.recv()
-                self.logger.debug(f"Welcome message: {welcome}")
-            except Exception:
-                pass  # Welcome message is optional
-                
-        except Exception as e:
-            self.connected = False
-            self.ws = None
-            raise DebriefAPIError(f"Connection failed: {str(e)}")
-    
-    def send_raw_message(self, message: str) -> str:
-        """
-        Send a raw string message and return the response.
-        
+        Make an MCP JSON-RPC 2.0 request.
+
         Args:
-            message (str): The raw string message to send to the server
-        
+            method (str): The JSON-RPC method to call (e.g., "tools/call")
+            params (Optional[Dict[str, Any]]): Method parameters
+
         Returns:
-            str: The response from the server as a string
-        
+            Any: The result from the JSON-RPC response
+
         Raises:
-            DebriefAPIError: When connection fails or message sending fails
+            DebriefAPIError: When the request fails or server returns an error
         """
-        if not self.connected:
-            self.connect()
-            
-        if not self.connected or not self.ws:
-            raise DebriefAPIError("Not connected to Debrief")
-        
+        self._request_id += 1
+
+        request = {
+            "jsonrpc": "2.0",
+            "id": self._request_id,
+            "method": method,
+            "params": params or {}
+        }
+
         try:
-            # Send message
-            self.ws.send(message)
-            
-            # Receive response
-            response = self.ws.recv()
-            # Ensure we return a string
-            if isinstance(response, str):
-                return response
-            elif isinstance(response, bytes):
-                return response.decode('utf-8')
-            else:
-                return str(response)
-            
-        except Exception as e:
-            self.logger.error(f"Error sending message: {e}")
-            self.connected = False
-            self.ws = None
-            raise DebriefAPIError(f"Message send failed: {e}")
-    
-    def send_json_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Send a JSON message and return the parsed response.
-        
-        Args:
-            message (Dict[str, Any]): The JSON message dictionary to send
-        
-        Returns:
-            Dict[str, Any]: The parsed JSON response from the server
-        
-        Raises:
-            DebriefAPIError: When connection fails, message sending fails, or server returns an error
-        """
-        if not self.connected:
-            self.connect()
-        
-        # Check if this command uses filename parameter for optional filename handling
-        params = message.get('params', {})
-        if 'filename' in params:
-            # filename in params means this command supports filename handling
-            if params['filename'] is None:
-                # filename=None means: use single editor or let user choose
-                # Try the command without filename first
-                response = self._send_json_raw(message)
-                
-                # Check for MULTIPLE_PLOTS error and handle it
-                if ('error' in response and 
-                    response['error'].get('code') == 'MULTIPLE_PLOTS'):
-                    available_plots = response['error'].get('available_plots', [])
-                    selected_filename = self._prompt_plot_selection(available_plots)
-                    
-                    # Retry with selected filename
-                    message['params']['filename'] = selected_filename
-                    return self._send_json_raw(message)
-                    
-                return response
-            # else: filename has a value (use that specific file) - send directly
-        
-        # For commands without filename parameter, send directly
-        return self._send_json_raw(message)
-    
-    def _send_json_raw(self, message: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Send a JSON message without filename handling logic.
-        
-        Args:
-            message (Dict[str, Any]): The JSON message dictionary to send
-        
-        Returns:
-            Dict[str, Any]: The parsed JSON response from the server
-        
-        Raises:
-            DebriefAPIError: When message sending fails or JSON parsing fails
-        """
-        json_str = json.dumps(message)
-        response_str = self.send_raw_message(json_str)
-        
-        try:
-            response = json.loads(response_str)
-            
-            # Check for errors in response
-            if 'error' in response:
-                error_info = response['error']
-                
-                # Don't raise exception for MULTIPLE_PLOTS - let caller handle it
-                if error_info.get('code') == 'MULTIPLE_PLOTS':
-                    return response
-                    
+            response = self.session.post(self.mcp_url, json=request, timeout=30)
+            response.raise_for_status()
+
+            result = response.json()
+
+            if "error" in result:
+                error_info = result["error"]
                 raise DebriefAPIError(
-                    error_info.get('message', 'Unknown error'),
-                    error_info.get('code')
+                    error_info.get("message", "Unknown error"),
+                    error_info.get("code")
                 )
-                
-            return response
+
+            return result.get("result")
+
+        except requests.exceptions.ConnectionError as e:
+            raise DebriefAPIError(f"Connection failed: {str(e)}")
+        except requests.exceptions.Timeout as e:
+            raise DebriefAPIError(f"Request timed out: {str(e)}")
+        except requests.exceptions.HTTPError as e:
+            raise DebriefAPIError(f"HTTP error: {str(e)}")
         except json.JSONDecodeError as e:
-            raise DebriefAPIError(f"Invalid JSON response: {e}")
-    
-    def _prompt_plot_selection(self, available_plots: List[Dict[str, str]]) -> str:
+            raise DebriefAPIError(f"Invalid JSON response: {str(e)}")
+
+    def call_tool(self, tool_name: str, arguments: Optional[Dict[str, Any]] = None) -> Any:
         """
-        Prompt user to select from available plots.
-        
+        Call an MCP tool.
+
         Args:
-            available_plots (List[Dict[str, str]]): List of plot dictionaries with 'filename' and 'title' keys
-        
+            tool_name (str): Name of the tool to call
+            arguments (Optional[Dict[str, Any]]): Tool arguments
+
         Returns:
-            str: The filename of the selected plot
-        
+            Any: Tool execution result
+
         Raises:
-            DebriefAPIError: When no plots are available
-            SystemExit: When user chooses to quit (via 'Q' input or Ctrl+C)
+            DebriefAPIError: When tool execution fails
         """
-        if not available_plots:
-            raise DebriefAPIError("No plots available")
-        
-        if len(available_plots) == 1:
-            return available_plots[0]['filename']
-        
-        print("\nMultiple plot files are open. Please select one:")
-        for i, plot in enumerate(available_plots, 1):
-            print(f"{i}. {plot['title']} ({plot['filename']})")
-        print("\nOr enter 'Q' to quit.")
-        
-        while True:
-            try:
-                choice = input("\nEnter your choice (1-{} or Q): ".format(len(available_plots)))
-                
-                # Check for quit command
-                if choice.lower() in ['q', 'quit', 'exit']:
-                    print("Exiting script.")
-                    sys.exit(0)
-                
-                choice_num = int(choice) - 1
-                if 0 <= choice_num < len(available_plots):
-                    selected = available_plots[choice_num]
-                    print(f"Selected: {selected['title']}")
-                    return selected['filename']
-                else:
-                    print(f"Please enter a number between 1 and {len(available_plots)}, or 'Q' to quit.")
-            except KeyboardInterrupt:
-                # Handle Ctrl+C - exit gracefully
-                print("\nExiting script.")
-                sys.exit(0)
-            except ValueError:
-                print("Invalid input. Please enter a number (1-{}) or 'Q' to quit.".format(len(available_plots)))
-            except EOFError:
-                # Handle cases where input stream is closed
-                print("\nInput stream closed. Exiting script.")
-                sys.exit(0)
-    
-    def cleanup(self) -> None:
-        """
-        Clean up resources.
-        
-        Returns:
-            None: Method returns nothing, closes WebSocket connection and resets state
-        """
-        if self.ws:
-            try:
-                self.ws.close()
-            except Exception:
-                pass
-            self.ws = None
-        self.connected = False
+        return self._call_mcp("tools/call", {
+            "name": tool_name,
+            "arguments": arguments or {}
+        })
 
 
 class DebriefAPI:
     """
     Main API class providing discoverable methods for VS Code Debrief extension integration.
-    
-    This class wraps the WebSocket client to provide a clean, discoverable API interface
+
+    This class wraps the MCP HTTP client to provide a clean, discoverable API interface
     that enables IDE auto-completion and better developer experience.
-    
+
     Usage:
         from debrief_api import debrief
-        
-        # Connect and send notification
-        debrief.connect()
+
+        # Send notification
         debrief.notify("Hello from Python!")
-        
+
         # Work with plot features
         features = debrief.get_feature_collection("my_plot.plot.json")
         selected = debrief.get_selected_features("my_plot.plot.json")
     """
-    
+
     def __init__(self):
-        self._client = DebriefWebSocketClient()
-    
-    def connect(self) -> None:
-        """
-        Connect to the Debrief WebSocket server.
-        
-        Returns:
-            None: Method returns nothing but establishes connection for subsequent API calls
-        
-        Raises:
-            DebriefAPIError: When connection to WebSocket server fails
-        """
-        self._client.connect()
-    
-    def send_raw_message(self, message: str) -> str:
-        """
-        Send a raw message to the server.
-        
-        Args:
-            message (str): The raw string message to send
-        
-        Returns:
-            str: The response from the server as a string
-        
-        Raises:
-            DebriefAPIError: When connection fails or message sending fails
-        """
-        return self._client.send_raw_message(message)
-    
-    def send_json_message(self, message: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Send a JSON message to the server.
-        
-        Args:
-            message (Dict[str, Any]): The JSON message dictionary to send
-        
-        Returns:
-            Dict[str, Any]: The parsed JSON response from the server
-        
-        Raises:
-            DebriefAPIError: When connection fails, message sending fails, or server returns an error
-        """
-        return self._client.send_json_message(message)
-    
+        self._client = DebriefMCPClient()
+
     def notify(self, message: str) -> None:
         """
         Display a notification in VS Code.
-        
+
         Args:
             message (str): The notification message text to display
-        
-        Returns:
-            None: Method returns nothing but triggers a notification in VS Code
-        
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "notify",
-            "params": {
-                "message": message
-            }
-        }
-        self._client.send_json_message(command)
-    
+        # Note: notify is not exposed as an MCP tool yet, but we can implement it if needed
+        raise NotImplementedError("notify() is not available via MCP endpoint")
+
     def get_feature_collection(self, filename: Optional[str] = None) -> Dict[str, Any]:
         """
         Get the feature collection for a plot file.
-        
+
         Args:
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
+            filename (Optional[str]): The plot file name. If None, uses single open plot
+
         Returns:
-            Dict[str, Any]: The GeoJSON FeatureCollection dictionary containing all features in the plot
-        
+            Dict[str, Any]: The GeoJSON FeatureCollection dictionary
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "get_feature_collection",
-            "params": {
-                "filename": filename
-            }
-        }
-        
-        response = self._client.send_json_message(command)
-        return response.get('result', {})
-    
+        arguments = {}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        return self._client.call_tool("debrief_get_features", arguments)
+
     def set_feature_collection(self, fc: Dict[str, Any], filename: Optional[str] = None) -> None:
         """
         Set the feature collection for a plot file.
-        
+
         Args:
-            fc (Dict[str, Any]): The GeoJSON FeatureCollection dictionary to set
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but updates the plot with the new feature collection
-        
+            fc (Dict[str, Any]): The GeoJSON FeatureCollection dictionary
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "set_feature_collection",
-            "params": {
-                "data": fc,
-                "filename": filename
-            }
-        }
-        
-        self._client.send_json_message(command)
-    
+        arguments = {"command": {"featureCollection": fc}}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_apply_command", arguments)
+
     def get_selected_features(self, filename: Optional[str] = None) -> SelectionState:
         """
         Get the currently selected features for a plot file.
-        
+
         Args:
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
+            filename (Optional[str]): The plot file name
+
         Returns:
             SelectionState: SelectionState object containing selected feature IDs
-        
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "get_selected_features",
-            "params": {
-                "filename": filename
-            }
-        }
-        
-        response = self._client.send_json_message(command)
-        result = response.get('result', [])
-        # Convert the list of features to feature IDs for SelectionState
+        arguments = {}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        result = self._client.call_tool("debrief_get_selection", arguments)
+
+        # The tool returns an array of feature objects, extract IDs
         selected_ids = []
         if isinstance(result, list):
             for feature in result:
                 if isinstance(feature, dict) and 'id' in feature:
-                    selected_ids.append(feature['id'])
+                    selected_ids.append(str(feature['id']))
+
         return SelectionState(selectedIds=selected_ids)
-    
+
     def set_selected_features(self, selection_state: SelectionState, filename: Optional[str] = None) -> None:
         """
         Set the selected features for a plot file.
-        
+
         Args:
-            selection_state (SelectionState): SelectionState object containing feature IDs to select
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but updates the selection state in the plot
-        
+            selection_state (SelectionState): SelectionState object
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "set_selected_features",
-            "params": {
-                "ids": selection_state.selectedIds,
-                "filename": filename
-            }
-        }
-        
-        self._client.send_json_message(command)
-    
+        # Use apply_command to set selection
+        arguments = {"command": {"selectionState": selection_state.model_dump(mode='json')}}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_apply_command", arguments)
+
     def update_features(self, features: List[Dict[str, Any]], filename: Optional[str] = None) -> None:
         """
         Update features in a plot file.
-        
+
         Args:
-            features (List[Dict[str, Any]]): List of GeoJSON Feature dictionaries to update (must have matching IDs)
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but updates the specified features in the plot
-        
+            features (List[Dict[str, Any]]): List of GeoJSON Feature dictionaries
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "update_features",
-            "params": {
-                "features": features,
-                "filename": filename
-            }
-        }
-        
-        self._client.send_json_message(command)
-    
+        arguments = {"command": {"features": features, "operation": "update"}}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_apply_command", arguments)
+
     def add_features(self, features: List[Dict[str, Any]], filename: Optional[str] = None) -> None:
         """
         Add new features to a plot file.
-        
+
         Args:
-            features (List[Dict[str, Any]]): List of GeoJSON Feature dictionaries to add to the plot
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but adds the features to the plot
-        
+            features (List[Dict[str, Any]]): List of GeoJSON Feature dictionaries
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "add_features",
-            "params": {
-                "features": features,
-                "filename": filename
-            }
-        }
-        
-        self._client.send_json_message(command)
-    
+        arguments = {"command": {"features": features, "operation": "add"}}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_apply_command", arguments)
+
     def delete_features(self, ids: List[str], filename: Optional[str] = None) -> None:
         """
         Delete features from a plot file.
-        
+
         Args:
             ids (List[str]): List of feature IDs to delete
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but removes the specified features from the plot
-        
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "delete_features",
-            "params": {
-                "ids": ids,
-                "filename": filename
-            }
-        }
-        
-        self._client.send_json_message(command)
-    
+        arguments = {"command": {"ids": ids, "operation": "delete"}}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_apply_command", arguments)
+
     def zoom_to_selection(self, filename: Optional[str] = None) -> None:
         """
         Zoom to the selected features in a plot file.
-        
+
         Args:
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but adjusts the viewport to fit selected features
-        
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "zoom_to_selection",
-            "params": {
-                "filename": filename
-            }
-        }
-        
-        self._client.send_json_message(command)
-    
+        arguments = {"command": {"operation": "zoom_to_selection"}}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_apply_command", arguments)
+
     def list_open_plots(self) -> List[Dict[str, str]]:
         """
         Get a list of currently open plot files.
-        
+
         Returns:
-            List[Dict[str, str]]: List of dictionaries with 'filename' and 'title' keys for each open plot
-        
+            List[Dict[str, str]]: List of dictionaries with 'filename' and 'title' keys
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "list_open_plots"
-        }
-        response = self._client.send_json_message(command)
-        return response.get('result', [])
-    
+        # This would require a new MCP tool - not implemented yet
+        raise NotImplementedError("list_open_plots() is not available via MCP endpoint")
+
     def get_time(self, filename: Optional[str] = None) -> Optional[TimeState]:
         """
         Get the current time state for a plot file.
-        
+
         Args:
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
+            filename (Optional[str]): The plot file name
+
         Returns:
-            Optional[TimeState]: TimeState object with current time settings, or None if not available
-        
+            Optional[TimeState]: TimeState object, or None if not available
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "get_time",
-            "params": {
-                "filename": filename
-            }
-        }
-        response = self._client.send_json_message(command)
-        result = response.get('result')
+        arguments = {}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        result = self._client.call_tool("debrief_get_time", arguments)
         if result is None:
             return None
         return TimeState.model_validate(result)
-    
+
     def set_time(self, time_state: TimeState, filename: Optional[str] = None) -> None:
         """
         Set the time state for a plot file.
-        
+
         Args:
-            time_state (TimeState): TimeState object containing time settings to apply
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but updates the time state in the plot
-        
+            time_state (TimeState): TimeState object
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "set_time",
-            "params": {
-                "timeState": time_state.model_dump(mode='json'),
-                "filename": filename
-            }
-        }
-        self._client.send_json_message(command)
-    
+        arguments = {"timeState": time_state.model_dump(mode='json')}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_set_time", arguments)
+
     def get_viewport(self, filename: Optional[str] = None) -> Optional[ViewportState]:
         """
         Get the current viewport state for a plot file.
-        
+
         Args:
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
+            filename (Optional[str]): The plot file name
+
         Returns:
-            Optional[ViewportState]: ViewportState object with zoom and center coordinates, or None if not available
-        
+            Optional[ViewportState]: ViewportState object, or None if not available
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "get_viewport",
-            "params": {
-                "filename": filename
-            }
-        }
-        response = self._client.send_json_message(command)
-        result = response.get('result')
+        arguments = {}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        result = self._client.call_tool("debrief_get_viewport", arguments)
         if result is None:
             return None
         return ViewportState.model_validate(result)
-    
+
     def set_viewport(self, viewport_state: ViewportState, filename: Optional[str] = None) -> None:
         """
         Set the viewport state for a plot file.
-        
+
         Args:
-            viewport_state (ViewportState): ViewportState object containing zoom and center coordinates
-            filename (Optional[str]): The plot file name. If None, uses single open plot or prompts for selection
-        
-        Returns:
-            None: Method returns nothing but updates the viewport in the plot
-        
+            viewport_state (ViewportState): ViewportState object
+            filename (Optional[str]): The plot file name
+
         Raises:
-            DebriefAPIError: When WebSocket communication fails or no plots are open
+            DebriefAPIError: When MCP communication fails
         """
-        command = {
-            "command": "set_viewport",
-            "params": {
-                "viewportState": viewport_state.model_dump(mode='json'),
-                "filename": filename
-            }
-        }
-        self._client.send_json_message(command)
+        arguments = {"viewportState": viewport_state.model_dump(mode='json')}
+        if filename is not None:
+            arguments["filename"] = filename
+
+        self._client.call_tool("debrief_set_viewport", arguments)
 
 
 # Global API instance for easy access with auto-completion

--- a/apps/vs-code/workspace/tests/requirements.txt
+++ b/apps/vs-code/workspace/tests/requirements.txt
@@ -1,2 +1,2 @@
-websocket-client>=1.6.0
+requests>=2.31.0
 geojson-pydantic>=2.0.0

--- a/libs/tool-vault-packager/cli.py
+++ b/libs/tool-vault-packager/cli.py
@@ -179,12 +179,20 @@ def serve_command(tools_path: str, port: int = 8000, host: str = "127.0.0.1"):
         # Create the app
         app = create_app(tools_path)
 
-        print(f"Server starting on http://{host}:{port}")
-        print(f"Web interface: http://{host}:{port}/ui/")
-        print(f"MCP API: http://{host}:{port}/tools/list")
+        print(f"Tool Vault Server starting on http://{host}:{port}")
         print(f"Tools directory: {tools_path}")
-        print("Additional endpoints:")
+        print("")
+        print("MCP Endpoints (LLM Integration):")
+        print(f"  - POST http://{host}:{port}/mcp")
+        print("")
+        print("Web interface:")
+        print(f"  - GET  http://{host}:{port}/ui/")
+        print("")
+        print("Legacy REST API (backward compatibility):")
+        print(f"  - GET  http://{host}:{port}/tools/list")
         print(f"  - POST http://{host}:{port}/tools/call")
+        print("")
+        print("System:")
         print(f"  - GET  http://{host}:{port}/health")
 
         # Start the server

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@vscode/codicons':
         specifier: ^0.0.40
         version: 0.0.40
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
       leaflet:
         specifier: ^1.9.4
         version: 1.9.4
@@ -42,6 +45,9 @@ importers:
       '@playwright/test':
         specifier: ^1.55.1
         version: 1.55.1
+      '@types/express':
+        specifier: ^5.0.3
+        version: 5.0.3
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -75,6 +81,9 @@ importers:
       ts-jest:
         specifier: ^29.4.1
         version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.25.9)(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@4.9.5)))(typescript@4.9.5)
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@18.19.124)(typescript@4.9.5)
       typescript:
         specifier: ^4.9.4
         version: 4.9.5
@@ -210,7 +219,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
+        version: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@4.9.5))
       jest-environment-jsdom:
         specifier: ^29.0.0
         version: 29.7.0
@@ -222,7 +231,7 @@ importers:
         version: 9.1.5(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@5.4.20(@types/node@18.19.124))
       ts-jest:
         specifier: ^29.0.0
-        version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2)))(typescript@5.9.2)
+        version: 29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.124))(typescript@5.9.2)
       typescript:
         specifier: ^5.0.0
         version: 5.9.2
@@ -1404,8 +1413,14 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
@@ -1416,11 +1431,20 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/express-serve-static-core@5.0.7':
+    resolution: {integrity: sha512-R+33OsgWw7rOhD1emjU7dzCDHucJrgJXMA5PYCzJxVil0dsyx5iBEPHqpPfiKNJQb7lZ1vxwoLR4Z87bBUpeGQ==}
+
+  '@types/express@5.0.3':
+    resolution: {integrity: sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==}
+
   '@types/geojson@7946.0.16':
     resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1446,11 +1470,20 @@ packages:
   '@types/lodash@4.17.20':
     resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
+  '@types/mime@1.3.5':
+    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
   '@types/node@18.19.124':
     resolution: {integrity: sha512-hY4YWZFLs3ku6D2Gqo3RchTd9VRCcrjqp/I0mmohYeUVA5Y8eCXKJEasHxLAJVZRJuQogfd1GiJ9lgogBgKeuQ==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/qs@6.14.0':
+    resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
   '@types/react-dom@18.3.7':
     resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
@@ -1470,6 +1503,12 @@ packages:
 
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
+
+  '@types/send@0.17.5':
+    resolution: {integrity: sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==}
+
+  '@types/serve-static@1.15.8':
+    resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -1646,6 +1685,10 @@ packages:
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
     deprecated: Use your platform's native atob() and btoa() methods instead
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
 
   acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
@@ -1837,6 +1880,10 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  body-parser@2.2.0:
+    resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
+    engines: {node: '>=18'}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1880,6 +1927,10 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -1999,8 +2050,24 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  content-disposition@1.0.0:
+    resolution: {integrity: sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
@@ -2124,6 +2191,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -2190,6 +2261,9 @@ packages:
     resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
     engines: {ecmascript: '>= es5', node: '>=4'}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   electron-to-chromium@1.5.217:
     resolution: {integrity: sha512-Pludfu5iBxp9XzNl0qq2G87hdD17ZV7h5T4n6rQXDi3nCyloBV3jreE9+8GC6g4X/5yxqVgXEURpcLtM0WS4jA==}
 
@@ -2202,6 +2276,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
@@ -2283,6 +2361,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
@@ -2361,6 +2442,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -2376,6 +2461,10 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express@5.1.0:
+    resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
+    engines: {node: '>= 18'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -2419,6 +2508,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@2.1.0:
+    resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
+    engines: {node: '>= 0.8'}
+
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
@@ -2449,6 +2542,14 @@ packages:
   form-data@4.0.4:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -2611,6 +2712,10 @@ packages:
   htmlparser2@10.0.0:
     resolution: {integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==}
 
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
@@ -2638,6 +2743,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.0:
+    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
     engines: {node: '>=0.10.0'}
 
   identity-obj-proxy@3.0.0:
@@ -2692,6 +2801,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -2793,6 +2906,9 @@ packages:
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3229,6 +3345,14 @@ packages:
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -3244,8 +3368,16 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.1:
+    resolution: {integrity: sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==}
     engines: {node: '>= 0.6'}
 
   mime@1.6.0:
@@ -3302,6 +3434,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
@@ -3377,6 +3513,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3460,6 +3600,10 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3486,6 +3630,9 @@ packages:
   path-scurry@2.0.0:
     resolution: {integrity: sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
@@ -3571,6 +3718,10 @@ packages:
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
@@ -3600,6 +3751,14 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.1:
+    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
+    engines: {node: '>= 0.10'}
 
   rc-config-loader@4.1.3:
     resolution: {integrity: sha512-kD7FqML7l800i6pS6pvLyIE2ncbk9Du8Q0gp/4hMPhJU6ZxApkoLcGD8ZeqgiAlfwZ6BlETq6qqe+12DUL207w==}
@@ -3725,6 +3884,10 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -3781,6 +3944,14 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.0:
+    resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.0:
+    resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
+    engines: {node: '>= 18'}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3792,6 +3963,9 @@ packages:
   set-proto@1.0.0:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3882,6 +4056,14 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -4044,6 +4226,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   touch@3.1.1:
     resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
     hasBin: true
@@ -4178,6 +4364,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-is@2.0.1:
+    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
+    engines: {node: '>= 0.6'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -4255,6 +4445,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
@@ -4290,6 +4484,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   version-range@4.15.0:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
@@ -4763,7 +4961,6 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
-    optional: true
 
   '@esbuild/aix-ppc64@0.19.12':
     optional: true
@@ -5105,41 +5302,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 18.19.124
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   '@jest/environment@29.7.0':
     dependencies:
       '@jest/fake-timers': 29.7.0
@@ -5290,7 +5452,6 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-    optional: true
 
   '@jsdevtools/ono@7.1.3': {}
 
@@ -5623,17 +5784,13 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@tsconfig/node10@1.0.11':
-    optional: true
+  '@tsconfig/node10@1.0.11': {}
 
-  '@tsconfig/node12@1.0.11':
-    optional: true
+  '@tsconfig/node12@1.0.11': {}
 
-  '@tsconfig/node14@1.0.3':
-    optional: true
+  '@tsconfig/node14@1.0.3': {}
 
-  '@tsconfig/node16@1.0.4':
-    optional: true
+  '@tsconfig/node16@1.0.4': {}
 
   '@types/aria-query@5.0.4': {}
 
@@ -5658,9 +5815,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.4
 
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 18.19.124
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 18.19.124
 
   '@types/deep-eql@4.0.2': {}
 
@@ -5668,11 +5834,26 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/express-serve-static-core@5.0.7':
+    dependencies:
+      '@types/node': 18.19.124
+      '@types/qs': 6.14.0
+      '@types/range-parser': 1.2.7
+      '@types/send': 0.17.5
+
+  '@types/express@5.0.3':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.0.7
+      '@types/serve-static': 1.15.8
+
   '@types/geojson@7946.0.16': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 18.19.124
+
+  '@types/http-errors@2.0.5': {}
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -5703,11 +5884,17 @@ snapshots:
 
   '@types/lodash@4.17.20': {}
 
+  '@types/mime@1.3.5': {}
+
   '@types/node@18.19.124':
     dependencies:
       undici-types: 5.26.5
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/qs@6.14.0': {}
+
+  '@types/range-parser@1.2.7': {}
 
   '@types/react-dom@18.3.7(@types/react@19.1.12)':
     dependencies:
@@ -5724,6 +5911,17 @@ snapshots:
   '@types/resolve@1.20.6': {}
 
   '@types/sarif@2.1.7': {}
+
+  '@types/send@0.17.5':
+    dependencies:
+      '@types/mime': 1.3.5
+      '@types/node': 18.19.124
+
+  '@types/serve-static@1.15.8':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 18.19.124
+      '@types/send': 0.17.5
 
   '@types/stack-utils@2.0.3': {}
 
@@ -6048,6 +6246,11 @@ snapshots:
 
   abab@2.0.6: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.1
+      negotiator: 1.0.0
+
   acorn-globals@7.0.1:
     dependencies:
       acorn: 8.15.0
@@ -6114,8 +6317,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  arg@4.1.3:
-    optional: true
+  arg@4.1.3: {}
 
   argparse@1.0.10:
     dependencies:
@@ -6288,6 +6490,20 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  body-parser@2.2.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.1(supports-color@5.5.0)
+      http-errors: 2.0.0
+      iconv-lite: 0.6.3
+      on-finished: 2.4.1
+      qs: 6.14.0
+      raw-body: 3.0.1
+      type-is: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   boolbase@1.0.0: {}
 
   boundary@2.0.0: {}
@@ -6335,6 +6551,8 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
+
+  bytes@3.1.2: {}
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6459,7 +6677,17 @@ snapshots:
       tree-kill: 1.2.2
       yargs: 17.7.2
 
+  content-disposition@1.0.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   create-jest@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@4.9.5)):
     dependencies:
@@ -6476,23 +6704,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2)):
-    dependencies:
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-      jest-util: 29.7.0
-      prompts: 2.4.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  create-require@1.1.1:
-    optional: true
+  create-require@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6616,6 +6828,8 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.0.4:
@@ -6625,8 +6839,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2:
-    optional: true
+  diff@4.0.2: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -6678,6 +6891,8 @@ snapshots:
     dependencies:
       version-range: 4.15.0
 
+  ee-first@1.1.1: {}
+
   electron-to-chromium@1.5.217: {}
 
   emittery@0.13.1: {}
@@ -6685,6 +6900,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
@@ -6909,6 +7126,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@2.0.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -7022,6 +7241,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -7046,6 +7267,38 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express@5.1.0:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.0
+      content-disposition: 1.0.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.1(supports-color@5.5.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.0
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.1
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.0
+      serve-static: 2.2.0
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
@@ -7087,6 +7340,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@2.1.0:
+    dependencies:
+      debug: 4.4.1(supports-color@5.5.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
@@ -7126,6 +7390,10 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0:
     optional: true
@@ -7305,6 +7573,14 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
   http-proxy-agent@5.0.0:
     dependencies:
       '@tootallnate/once': 2.0.0
@@ -7339,6 +7615,10 @@ snapshots:
   husky@9.1.7: {}
 
   iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -7386,6 +7666,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ipaddr.js@1.9.1: {}
 
   is-arguments@1.2.0:
     dependencies:
@@ -7479,6 +7761,8 @@ snapshots:
   is-number@7.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-promise@4.0.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -7650,25 +7934,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-config@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@4.9.5)):
     dependencies:
       '@babel/core': 7.28.4
@@ -7696,37 +7961,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 18.19.124
       ts-node: 10.9.2(@types/node@18.19.124)(typescript@4.9.5)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2)):
-    dependencies:
-      '@babel/core': 7.28.4
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.4)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 18.19.124
-      ts-node: 10.9.2(@types/node@18.19.124)(typescript@5.9.2)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -7973,18 +8207,6 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2)):
-    dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.1:
@@ -8223,6 +8445,10 @@ snapshots:
 
   mdurl@2.0.0: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -8234,9 +8460,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.1:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -8276,6 +8508,8 @@ snapshots:
     optional: true
 
   natural-compare@1.4.0: {}
+
+  negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
 
@@ -8367,6 +8601,10 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -8468,6 +8706,8 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parseurl@1.3.3: {}
+
   path-exists@4.0.0: {}
 
   path-exists@5.0.0: {}
@@ -8487,6 +8727,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.1
       minipass: 7.1.2
+
+  path-to-regexp@8.3.0: {}
 
   path-type@6.0.0: {}
 
@@ -8569,6 +8811,11 @@ snapshots:
       object-assign: 4.1.1
       react-is: 16.13.1
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   psl@1.15.0:
     dependencies:
       punycode: 2.3.1
@@ -8594,6 +8841,15 @@ snapshots:
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
+
+  range-parser@1.2.1: {}
+
+  raw-body@3.0.1:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.7.0
+      unpipe: 1.0.0
 
   rc-config-loader@4.1.3:
     dependencies:
@@ -8769,6 +9025,16 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.50.1
       fsevents: 2.3.3
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.1(supports-color@5.5.0)
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.3.0
+    transitivePeerDependencies:
+      - supports-color
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -8828,6 +9094,31 @@ snapshots:
 
   semver@7.7.2: {}
 
+  send@1.2.0:
+    dependencies:
+      debug: 4.4.1(supports-color@5.5.0)
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.0
+      mime-types: 3.0.1
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.0:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -8849,6 +9140,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -8944,6 +9237,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  statuses@2.0.1: {}
+
+  statuses@2.0.2: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -9153,6 +9450,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   touch@3.1.1: {}
 
   tough-cookie@4.1.4:
@@ -9180,12 +9479,12 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-jest@29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2)))(typescript@5.9.2):
+  ts-jest@29.4.1(@babel/core@7.28.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.4))(esbuild@0.19.12)(jest-util@29.7.0)(jest@29.7.0(@types/node@18.19.124))(typescript@5.9.2):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2))
+      jest: 29.7.0(@types/node@18.19.124)(ts-node@10.9.2(@types/node@18.19.124)(typescript@4.9.5))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -9239,26 +9538,6 @@ snapshots:
       typescript: 4.9.5
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
-    optional: true
-
-  ts-node@10.9.2(@types/node@18.19.124)(typescript@5.9.2):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 18.19.124
-      acorn: 8.15.0
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.9.2
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optional: true
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -9311,6 +9590,12 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
+
+  type-is@2.0.1:
+    dependencies:
+      content-type: 1.0.5
+      media-typer: 1.1.0
+      mime-types: 3.0.1
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -9405,6 +9690,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   unplugin@1.16.1:
     dependencies:
       acorn: 8.15.0
@@ -9432,8 +9719,7 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  v8-compile-cache-lib@3.0.1:
-    optional: true
+  v8-compile-cache-lib@3.0.1: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:
@@ -9445,6 +9731,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vary@1.1.2: {}
 
   version-range@4.15.0: {}
 
@@ -9598,8 +9886,7 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
 
-  yn@3.1.1:
-    optional: true
+  yn@3.1.1: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the MCP (Model Context Protocol) endpoint integration, enabling LLM tools like GitHub Copilot and Claude to orchestrate multi-step maritime analysis workflows through standardized JSON-RPC 2.0 HTTP endpoints.

This PR adds MCP endpoints to both the Debrief State Server (VS Code extension) and Tool Vault Server, while refactoring the Python client to use HTTP instead of WebSocket.

## Changes

### Debrief State Server (apps/vs-code)
- ✅ Added Express middleware to existing HTTP server (port 60123)
- ✅ Implemented `POST /mcp` endpoint with JSON-RPC 2.0 support
  - `tools/list`: Returns cached tool index from mcp-tools.json
  - `tools/call`: Routes to existing WebSocket command handlers
- ✅ Added `GET /health` endpoint for monitoring
- ✅ Created build-time tool index generator (scripts/generate-mcp-tools.ts)
  - Generates mcp-tools.json with 7 Debrief tools
  - Integrated into compile and vscode:prepublish scripts
- ✅ Non-breaking: WebSocket API remains fully functional

### Tool Vault Server (libs/tool-vault-packager)
- ✅ Implemented `POST /mcp` endpoint in server.py
  - `tools/list`: Converts internal tool index to MCP format
  - `tools/call`: Routes to existing tool execution logic
- ✅ MCP-only implementation per ADR 003 (clean, no legacy REST cruft)
- ✅ Updated startup logging to highlight MCP endpoint
- ✅ Error handling with proper JSON-RPC error codes (-32601, -32603, -32600)

### Python Client (apps/vs-code/workspace/tests)
- ✅ Refactored debrief_api.py from WebSocket to HTTP/MCP
  - Replaced `websocket-client` with `requests` library
  - Implemented `_call_mcp()` helper for JSON-RPC 2.0 requests
  - Maintained all existing API methods (get_feature_collection, set_time, etc.)
  - Simpler code: no connection management, no async complexity
- ✅ Updated requirements.txt (requests>=2.31.0)

## Dependencies Added
- **VS Code extension**: express@^5.1.0, ts-node@^10.9.2, @types/express@^5.0.3
- **Python**: requests library (replaces websocket-client)

## Testing
- ✅ All tests passing (pnpm test)
- ✅ Linting clean (ESLint, ruff)
- ✅ Type checking passing (TypeScript, mypy)
- ✅ Build artifacts generated correctly

## Test Plan
- [ ] VS Code extension builds successfully
- [ ] Debrief State Server starts and logs MCP endpoint
- [ ] Tool Vault Server starts and logs MCP endpoint
- [ ] Python scripts can connect via HTTP/MCP
- [ ] Existing Python test scripts continue to work
- [ ] GitHub Copilot can discover and call Debrief tools (Phase 2)

## Architecture Decisions
Implements:
- ✅ ADR 001: Streamable-HTTP MCP Transport
- ✅ ADR 003: MCP-Only Tool Vault
- ✅ ADR 004: Python Scripts via MCP

## Related Documentation
- docs/llm-integration/phases/phase-1-implementation.md
- docs/llm-integration/specs/debrief-state-server.md
- docs/llm-integration/specs/tool-vault-server.md

Closes #212