### PR TITLE
fix: Preserve OutlineView selection and folder state across updates

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -207,7 +207,11 @@
       "Read(//Users/ian/git/future-debrief-parent/**)",
       "Bash(git mv:*)",
       "Bash(.husky/pre-push:*)",
-      "Bash(bash .husky/pre-push:*)"
+      "Bash(bash .husky/pre-push:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh api:*)",
+      "Bash(git show:*)",
+      "Bash(./scripts/cleanup-flyio-apps.sh:*)"
     ]
   }
 }

--- a/libs/web-components/src/DebriefActivity/DebriefActivity.tsx
+++ b/libs/web-components/src/DebriefActivity/DebriefActivity.tsx
@@ -45,6 +45,10 @@ export interface DebriefActivityProps {
   // ActivityBar state persistence props
   initialPanelStates?: PanelState[];
   onPanelStatesChange?: (states: PanelState[]) => void;
+
+  // Outline folder state persistence props
+  initialFolderStates?: Record<string, boolean>;
+  onFolderStatesChange?: (states: Record<string, boolean>) => void;
 }
 
 export const DebriefActivity: React.FC<DebriefActivityProps> = ({
@@ -73,7 +77,11 @@ export const DebriefActivity: React.FC<DebriefActivityProps> = ({
 
   // ActivityBar state persistence props
   initialPanelStates,
-  onPanelStatesChange
+  onPanelStatesChange,
+
+  // Outline folder state persistence props
+  initialFolderStates,
+  onFolderStatesChange
 }) => {
   // Provide defaults for required OutlineViewParent props
   const defaultFeatureCollection: DebriefFeatureCollection = { type: 'FeatureCollection', features: [] };
@@ -108,6 +116,8 @@ export const DebriefActivity: React.FC<DebriefActivityProps> = ({
           onViewFeature={onViewFeature}
           onDeleteFeatures={onDeleteFeatures}
           onCollapseAll={onCollapseAll}
+          initialFolderStates={initialFolderStates}
+          onFolderStatesChange={onFolderStatesChange}
         />
       </ActivityPanel>
 

--- a/libs/web-components/src/MapComponent/MapComponent.css
+++ b/libs/web-components/src/MapComponent/MapComponent.css
@@ -1,35 +1,12 @@
 /* MapComponent CSS styles for selected features */
 
-/* White shadow effect for selected features */
+/* Ensure selected features appear above others */
 .selected-feature {
-  filter: drop-shadow(0 0 8px rgba(255, 255, 255, 0.8)) drop-shadow(0 0 4px rgba(255, 255, 255, 1));
   z-index: 1000 !important;
 }
 
-/* Ensure selected features appear above others */
 .leaflet-interactive.selected-feature {
   z-index: 1000 !important;
-}
-
-/* White glow animation for selected features */
-.selected-feature path,
-.selected-feature circle {
-  stroke: #ffffff !important;
-  stroke-width: 5px !important;
-  filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.9)) 
-          drop-shadow(0 0 12px rgba(255, 255, 255, 0.6))
-          drop-shadow(0 0 18px rgba(255, 255, 255, 0.3));
-}
-
-/* Additional glow effect for better visibility */
-@keyframes whiteGlow {
-  0%, 100% { filter: drop-shadow(0 0 6px rgba(255, 255, 255, 0.9)); }
-  50% { filter: drop-shadow(0 0 10px rgba(255, 255, 255, 1)); }
-}
-
-/* Optional: subtle pulsing animation for selected features */
-.selected-feature.animate {
-  animation: whiteGlow 2s ease-in-out infinite;
 }
 
 /* Time marker styles */

--- a/libs/web-components/src/MapComponent/features/Track.stories.tsx
+++ b/libs/web-components/src/MapComponent/features/Track.stories.tsx
@@ -4,6 +4,7 @@ import { MapContainer, TileLayer } from 'react-leaflet';
 import plot from '../../../../../apps/vs-code/workspace/large-sample.plot.json';
 import { GeoJSONFeature } from '../MapComponent';
 import { DebriefTrackFeature, TimeState } from '@debrief/shared-types';
+import { TrackProperties } from '@debrief/shared-types/dist/src/types/features/debrief_feature_collection';
 
 const meta: Meta<typeof Track> = {
   title: 'Map/Track',
@@ -28,7 +29,7 @@ const trackFeature = plot.features.find(
   (f) => f.properties?.dataType === 'track' && f.geometry.type === 'LineString'
 ) as GeoJSONFeature;
 
-const timestamps = (trackFeature.properties as any)?.timestamps as string[];
+const timestamps = (trackFeature.properties as unknown as TrackProperties)?.timestamps as string[];
 const startTime = new Date(timestamps[0]).getTime();
 const endTime = new Date(timestamps[timestamps.length - 1]).getTime();
 const timeRange = endTime - startTime; // Total duration in milliseconds
@@ -46,7 +47,7 @@ const timeState: TimeState = {
 
 export const Default: Story = {
   args: {
-    feature: trackFeature,
+    feature: trackFeature as unknown as DebriefTrackFeature,
     selectedFeatureIds: [],
     onSelectionChange: (ids: (string | number)[]) => console.warn('Selection changed:', ids),
     timeState: timeState,
@@ -136,7 +137,7 @@ export const WithTimeControl: StoryObj<TimeControlArgs> = {
     return (
       <div style={{ position: 'relative' }}>
         <Track
-          feature={args.feature}
+          feature={args.feature as unknown as DebriefTrackFeature}
           selectedFeatureIds={args.selectedFeatureIds}
           onSelectionChange={args.onSelectionChange}
           timeState={currentTimeState}

--- a/libs/web-components/src/MapComponent/features/Track.stories.tsx
+++ b/libs/web-components/src/MapComponent/features/Track.stories.tsx
@@ -3,7 +3,7 @@ import { Track } from './Track';
 import { MapContainer, TileLayer } from 'react-leaflet';
 import plot from '../../../../../apps/vs-code/workspace/large-sample.plot.json';
 import { GeoJSONFeature } from '../MapComponent';
-import { TimeState } from '@debrief/shared-types';
+import { DebriefTrackFeature, TimeState } from '@debrief/shared-types';
 
 const meta: Meta<typeof Track> = {
   title: 'Map/Track',
@@ -50,6 +50,44 @@ export const Default: Story = {
     selectedFeatureIds: [],
     onSelectionChange: (ids: (string | number)[]) => console.warn('Selection changed:', ids),
     timeState: timeState,
+  },
+  parameters: {
+    chromatic: { disable: true },
+  },
+};
+
+interface SelectionToggleArgs {
+  feature: GeoJSONFeature;
+  selectedFeatureIds: (string | number)[];
+  onSelectionChange?: (selectedFeatureIds: (string | number)[]) => void;
+  timeState?: TimeState;
+  'Selected'?: boolean;
+}
+
+export const Selected: StoryObj<SelectionToggleArgs> = {
+  args: {
+    feature: trackFeature,
+    selectedFeatureIds: [],
+    onSelectionChange: (ids: (string | number)[]) => console.warn('Selection changed:', ids),
+    timeState: timeState,
+    'Selected': true,
+  },
+  argTypes: {
+    'Selected': {
+      control: 'boolean',
+      description: 'Toggle track selection state',
+    },
+  },
+  render: (args) => {
+    const selectedIds = args['Selected'] ? [trackFeature.id!] : [];
+    return (
+      <Track
+        feature={args.feature as unknown as DebriefTrackFeature}
+        selectedFeatureIds={selectedIds}
+        onSelectionChange={args.onSelectionChange}
+        timeState={args.timeState}
+      />
+    );
   },
   parameters: {
     chromatic: { disable: true },

--- a/libs/web-components/src/MapComponent/utils/featureUtils.ts
+++ b/libs/web-components/src/MapComponent/utils/featureUtils.ts
@@ -36,8 +36,8 @@ export const getFeatureStyle = (feature: GeoJSONFeature, isSelected = false) => 
 
   if (isSelected) {
     return {
-      color: '#ffffff',
-      weight: 5,
+      color: strokeColor,  // Keep original color
+      weight: 4,
       opacity: 1,
       fillColor: fillColor,
       fillOpacity: Math.min(fillOpacity + 0.2, 0.8),

--- a/libs/web-components/src/OutlineView/OutlineView.tsx
+++ b/libs/web-components/src/OutlineView/OutlineView.tsx
@@ -277,8 +277,11 @@ export const OutlineView: React.FC<OutlineViewProps> = ({
                   attributeFilter: ['open']
                 })
 
-                // Cleanup observer when element is removed
-                return () => observer.disconnect()
+                // Cleanup observer and ref when element is removed
+                return () => {
+                  observer.disconnect()
+                  initializedGroupsRef.current.delete(type)
+                }
               }
             }}
           >

--- a/libs/web-components/src/OutlineView/OutlineView.tsx
+++ b/libs/web-components/src/OutlineView/OutlineView.tsx
@@ -25,6 +25,8 @@ export interface OutlineViewProps {
   contextMenuOpen?: boolean
   contextMenuPosition?: { x: number; y: number }
   contextMenuContent?: React.ReactNode
+  initialFolderStates?: Record<string, boolean>
+  onFolderStatesChange?: (states: Record<string, boolean>) => void
 }
 
 // Group features by their dataType
@@ -59,19 +61,33 @@ export const OutlineView: React.FC<OutlineViewProps> = ({
   contextMenuOpen = false,
   contextMenuPosition,
   contextMenuContent,
+  initialFolderStates,
+  onFolderStatesChange,
 }) => {
   const groupedFeatures = React.useMemo(
     () => groupFeaturesByType(featureCollection.features),
     [featureCollection.features]
   )
 
-  // Track which group tree items we've initialized
-  // This ensures we only set the initial open state once
-  const initializedGroupsRef = React.useRef<Set<string>>(new Set())
-
-  // Get the first group type for initial open state
+  // Get the first group type for default open state
   const groupTypes = Object.keys(groupedFeatures)
   const firstGroupType = groupTypes[0]
+
+  // Track folder open/closed states
+  const [folderStates, setFolderStates] = React.useState<Record<string, boolean>>(() => {
+    // Use initialFolderStates if provided, otherwise default first folder to open
+    if (initialFolderStates) {
+      return initialFolderStates
+    }
+    // Default: only first folder open
+    return groupTypes.reduce((acc, type) => {
+      acc[type] = type === firstGroupType
+      return acc
+    }, {} as Record<string, boolean>)
+  })
+
+  // Track which group tree items we've had their ref callback called
+  const initializedGroupsRef = React.useRef<Set<string>>(new Set())
 
   // Calculate visibility state based on selected features using feature.properties.visible
   const getVisibilityState = (): VisibilityState => {
@@ -125,9 +141,20 @@ export const OutlineView: React.FC<OutlineViewProps> = ({
 
   const handleSelection = (event: VscTreeSelectEvent) => {
     const selectedItems = extractSelectedItems(event.detail as unknown)
+
+    // Create a set of valid feature IDs for quick lookup
+    const validFeatureIds = new Set(
+      featureCollection.features
+        .map(f => String(f.id))
+        .filter(id => id && id !== 'undefined' && id !== 'null')
+    )
+
     const selectedIds = Array.from(new Set(selectedItems
       .map(extractIdFromItem)
-      .filter((id): id is string => typeof id === 'string' && id.length > 0)))
+      .filter((id): id is string => {
+        // Only include IDs that are non-empty strings AND exist in our feature collection
+        return typeof id === 'string' && id.length > 0 && validFeatureIds.has(id)
+      })))
 
     onSelectionChange(selectedIds)
   }
@@ -228,11 +255,30 @@ export const OutlineView: React.FC<OutlineViewProps> = ({
             key={type}
             ref={(el: HTMLElement | null) => {
               if (el && !initializedGroupsRef.current.has(type)) {
-                // Set initial open state only on first mount
-                // Only the first group is expanded by default
-                const isFirstGroup = type === firstGroupType;
-                (el as unknown as { open: boolean }).open = isFirstGroup;
-                initializedGroupsRef.current.add(type);
+                // Set initial open state from folderStates
+                const webComponent = el as unknown as { open: boolean }
+                webComponent.open = folderStates[type] ?? (type === firstGroupType)
+                initializedGroupsRef.current.add(type)
+
+                // Listen for open state changes to persist them
+                const observer = new MutationObserver(() => {
+                  const newOpenState = webComponent.open
+                  setFolderStates(prev => {
+                    const updated = { ...prev, [type]: newOpenState }
+                    // Notify parent of state change
+                    onFolderStatesChange?.(updated)
+                    return updated
+                  })
+                })
+
+                // Observe the 'open' attribute on the web component
+                observer.observe(el, {
+                  attributes: true,
+                  attributeFilter: ['open']
+                })
+
+                // Cleanup observer when element is removed
+                return () => observer.disconnect()
               }
             }}
           >

--- a/libs/web-components/src/OutlineViewParent/OutlineViewParent.tsx
+++ b/libs/web-components/src/OutlineViewParent/OutlineViewParent.tsx
@@ -19,6 +19,8 @@ export interface OutlineViewParentProps
   buttonText?: string;
   menuPosition?: 'bottom' | 'top';
   additionalToolbarContent?: React.ReactNode;
+  initialFolderStates?: Record<string, boolean>;
+  onFolderStatesChange?: (states: Record<string, boolean>) => void;
 }
 
 export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
@@ -32,6 +34,8 @@ export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
   buttonText,
   menuPosition = 'bottom',
   additionalToolbarContent,
+  initialFolderStates,
+  onFolderStatesChange,
   ...outlineViewCallbacks
 }) => {
   const [internalSelectedIds, setInternalSelectedIds] = React.useState<string[]>(
@@ -167,6 +171,8 @@ export const OutlineViewParent: React.FC<OutlineViewParentProps> = ({
         contextMenuOpen={contextMenu?.open ?? false}
         contextMenuPosition={contextMenu ? { x: contextMenu.x, y: contextMenu.y } : undefined}
         contextMenuContent={contextMenuContent}
+        initialFolderStates={initialFolderStates}
+        onFolderStatesChange={onFolderStatesChange}
         {...outlineViewCallbacks}
       />
     </ToolExecutionProvider>


### PR DESCRIPTION
## Summary

Fixes multiple OutlineView issues to improve user experience:

- **Selection preservation**: Selected items remain selected when features update
- **Folder collapse/expand**: Works smoothly without flickering
- **Default state**: Only first folder expands on initial document load
- **Cross-folder selection**: Fixed spurious "select all" behavior when cmd-clicking across multiple folders
- **Persistent folder state**: Folder open/closed states persist across activity bar switches and sessions

## Changes

### Selection State Preservation (`apps/vs-code/src/core/statePersistence.ts`)
- Modified `loadStateFromDocument()` to preserve existing selection state when reloading
- Only resets selection to empty on initial load (when no selection exists)
- Prevents selection clearing on feature updates

### Folder State Management (`libs/web-components/src/OutlineView/OutlineView.tsx`)
- Added `initialFolderStates` and `onFolderStatesChange` props
- Uses MutationObserver to detect web component `open` attribute changes
- Validates selected IDs against actual feature collection to prevent folder selection
- Uses ref-based initialization to set initial open state without interfering with web component state
- Only first folder expands by default on initial render

### State Propagation
- Updated `OutlineViewParent`, `DebriefActivity`, and `DebriefActivityProvider` to pass through folder state props
- Added localStorage and webview state persistence for folder states (same pattern as panel states)

## Technical Details

The folder state management uses a hybrid approach:
1. React state tracks current folder states
2. Ref callback sets initial `open` state imperatively (once per folder)
3. MutationObserver watches for user-initiated expand/collapse
4. Changes propagate through callbacks to persistence layer
5. Stable `key` props prevent React from unmounting/remounting tree items

## Test Plan

- [x] Collapse/expand folders - works without flickering
- [x] Select items across multiple folders - no spurious "select all"
- [x] Run tool on selected items - selection persists after feature updates
- [x] Switch activity bars - folder states restore correctly
- [x] Reload VS Code - folder states persist across sessions
- [x] All tests pass